### PR TITLE
Use strings rather than pointers for newly required params

### DIFF
--- a/cmd/get_sizes.go
+++ b/cmd/get_sizes.go
@@ -29,8 +29,8 @@ var (
 			var err error
 			res, err = client.ReadSizes(cmd.Context(), &skysql.ReadSizesParams{
 				Limit:    &limit,
-				Product:  &product,
-				Provider: &provider,
+				Product:  product,
+				Provider: provider,
 			})
 
 			checkAndPrint(res, err, SIZES)

--- a/cmd/get_topologies.go
+++ b/cmd/get_topologies.go
@@ -27,7 +27,7 @@ var (
 			var err error
 			res, err = client.ReadTopologies(cmd.Context(), &skysql.ReadTopologiesParams{
 				Limit:   &limit,
-				Product: &product,
+				Product: product,
 			})
 
 			checkAndPrint(res, err, TOPOLOGIES)


### PR DESCRIPTION
Now that those params are required properly in the API, the SDK updated
to make them into actual string fields instead of *string fields. This
means they are no longer nil-able, and must be supplied.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [x] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
