### PR TITLE
Rename "database" to "service" for all resources

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -29,8 +29,8 @@ const (
 	COMMENT         = "comment"
 	CONFIGURATION   = "configuration"
 	CONFIGURATIONS  = "configurations"
-	DATABASE        = "database"
-	DATABASES       = "databases"
+	SERVICE         = "service"
+	SERVICES        = "services"
 	IP_ADDRESS      = "ip-address"
 	MACHINE         = "machine"
 	PRODUCT         = "product"
@@ -55,30 +55,30 @@ const (
 
 // hints
 const (
-	HINT_DB_ID = "Specify a database using the database id (e.g. db00000000)"
-	HINT_LIMIT = "Maximum number of results to retrieve"
+	HINT_SVC_ID = "Specify a service using the service id (e.g. db00000000)"
+	HINT_LIMIT  = "Maximum number of results to retrieve"
 )
 
 // defaults
 const (
 	DEFAULT_GET_LIMIT = 10
 
-	DEFAULT_CREATE_DATABASE_RELEASE_VERSION = "MariaDB Enterprise Server 10.5.9-6"
-	DEFAULT_CREATE_DATABASE_TOPOLOGY        = "Standalone"
-	DEFAULT_CREATE_DATABASE_SIZE            = "Sky-2x4"
-	DEFAULT_CREATE_DATABASE_TXSTORAGE       = "100"
-	DEFAULT_CREATE_DATABASE_MAXSCALE_CONFIG = ""
-	DEFAULT_CREATE_DATABASE_NAME            = ""
-	DEFAULT_CREATE_DATABASE_REGION          = ""
-	DEFAULT_CREATE_DATABASE_REPL_REGION     = ""
-	DEFAULT_CREATE_DATABASE_PROVIDER        = ""
-	DEFAULT_CREATE_DATABASE_REPLICAS        = "0"
-	DEFAULT_CREATE_DATABASE_MONITOR         = "false"
-	DEFAULT_CREATE_DATABASE_MAXSCALE_PROXY  = "false"
-	DEFAULT_CREATE_DATABASE_VOLUME_IOPS     = ""
-	DEFAULT_CREATE_DATABASE_VOLUME_TYPE     = ""
+	DEFAULT_CREATE_SERVICE_RELEASE_VERSION = ""
+	DEFAULT_CREATE_SERVICE_TOPOLOGY        = "Standalone"
+	DEFAULT_CREATE_SERVICE_SIZE            = "Sky-2x4"
+	DEFAULT_CREATE_SERVICE_TXSTORAGE       = "100"
+	DEFAULT_CREATE_SERVICE_MAXSCALE_CONFIG = ""
+	DEFAULT_CREATE_SERVICE_NAME            = ""
+	DEFAULT_CREATE_SERVICE_REGION          = ""
+	DEFAULT_CREATE_SERVICE_REPL_REGION     = ""
+	DEFAULT_CREATE_SERVICE_PROVIDER        = ""
+	DEFAULT_CREATE_SERVICE_REPLICAS        = "0"
+	DEFAULT_CREATE_SERVICE_MONITOR         = "false"
+	DEFAULT_CREATE_SERVICE_MAXSCALE_PROXY  = "false"
+	DEFAULT_CREATE_SERVICE_VOLUME_IOPS     = ""
+	DEFAULT_CREATE_SERVICE_VOLUME_TYPE     = ""
 
-	DEFAULT_UPDATE_DATABASE_NAME = ""
+	DEFAULT_UPDATE_SERVICE_NAME = ""
 
 	DEFAULT_CREATE_CONFIGURATION_TOPOLOGY    = "Primary/Replica"
 	DEFAULT_CREATE_CONFIGURATION_NAME        = "HA"

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	createValidArgs = []string{DATABASE}
+	createValidArgs = []string{SERVICE}
 	createCmd       = &cobra.Command{
 		Use:       CREATE,
 		Short:     "Create a resource in MariaDB SkySQL",

--- a/cmd/create_allowed_address.go
+++ b/cmd/create_allowed_address.go
@@ -11,15 +11,15 @@ import (
 
 var (
 	createAllowedAddressCmd = &cobra.Command{
-		Use:   fmt.Sprintf("%s [%s] [%s]", ALLOWED_ADDRESS, strings.ToUpper(DATABASE), strings.ToUpper(IP_ADDRESS)),
-		Short: fmt.Sprintf("Add a new %s to a %s", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), DATABASE),
-		Long:  fmt.Sprintf("Adds a new %s for %s in MariaDB SkySQL.", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), DATABASE),
+		Use:   fmt.Sprintf("%s [%s] [%s]", ALLOWED_ADDRESS, strings.ToUpper(SERVICE), strings.ToUpper(IP_ADDRESS)),
+		Short: fmt.Sprintf("Add a new %s to a %s", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), SERVICE),
+		Long:  fmt.Sprintf("Adds a new %s for %s in MariaDB SkySQL.", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), SERVICE),
 		Args:  cobra.ExactArgs(2),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag(COMMENT, cmd.Flags().Lookup(COMMENT))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			databaseId := string(args[0])
+			serviceID := string(args[0])
 			ip_address := string(args[1])
 			comment := viper.GetString(COMMENT)
 
@@ -27,7 +27,7 @@ var (
 				Comment:   &comment,
 				IpAddress: ip_address,
 			}
-			res, err := client.AddAllowedAddress(cmd.Context(), databaseId, reqBody)
+			res, err := client.AddAllowedAddress(cmd.Context(), serviceID, reqBody)
 			checkAndPrint(res, err, ALLOWED_ADDRESS)
 		},
 	}

--- a/cmd/create_database.go
+++ b/cmd/create_database.go
@@ -10,10 +10,10 @@ import (
 )
 
 var (
-	createDatabaseCmd = &cobra.Command{
-		Use:   DATABASE,
-		Short: "Create a new database",
-		Long:  `Submits request to MariaDB SkySQL to deploy a new database`,
+	createServiceCmd = &cobra.Command{
+		Use:   SERVICE,
+		Short: "Create a new service",
+		Long:  `Submits request to MariaDB SkySQL to deploy a new service`,
 		Args:  cobra.NoArgs,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag(RELEASE_VERSION, cmd.Flags().Lookup(RELEASE_VERSION))
@@ -33,47 +33,53 @@ var (
 			viper.BindPFlag(TIER, cmd.Flags().Lookup(TIER))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			reqBody := skysql.CreateDatabaseJSONRequestBody{
+			maxscaleConfig := viper.GetString(MAXSCALE_CONFIG)
+			replRegion := viper.GetString(REPL_REGION)
+			monitor := viper.GetString(MONITOR)
+			maxscaleProxy := viper.GetString(MAXSCALE_PROXY)
+			volumeIOPS := viper.GetString(VOLUME_IOPS)
+			volumeType := viper.GetString(VOLUME_TYPE)
+			reqBody := skysql.CreateServiceJSONRequestBody{
 				ReleaseVersion: viper.GetString(RELEASE_VERSION),
 				Topology:       viper.GetString(TOPOLOGY),
 				Size:           viper.GetString(SIZE),
 				TxStorage:      viper.GetString(STORAGE),
-				MaxscaleConfig: viper.GetString(MAXSCALE_CONFIG),
+				MaxscaleConfig: &maxscaleConfig,
 				Name:           viper.GetString(NAME),
 				Region:         viper.GetString(REGION),
-				ReplRegion:     viper.GetString(REPL_REGION),
+				ReplRegion:     &replRegion,
 				Provider:       viper.GetString(PROVIDER),
 				Replicas:       viper.GetString(REPLICAS),
-				Monitor:        viper.GetString(MONITOR),
-				MaxscaleProxy:  viper.GetString(MAXSCALE_PROXY),
-				VolumeIops:     viper.GetString(VOLUME_IOPS),
-				VolumeType:     viper.GetString(VOLUME_TYPE),
+				Monitor:        &monitor,
+				MaxscaleProxy:  &maxscaleProxy,
+				VolumeIops:     &volumeIOPS,
+				VolumeType:     &volumeType,
 				Tier:           viper.GetString(TIER),
 			}
 
-			res, err := client.CreateDatabase(cmd.Context(), reqBody)
+			res, err := client.CreateService(cmd.Context(), reqBody)
 
-			checkAndPrint(res, err, DATABASES)
+			checkAndPrint(res, err, SERVICES)
 		},
 	}
 )
 
 func init() {
-	createCmd.AddCommand(createDatabaseCmd)
+	createCmd.AddCommand(createServiceCmd)
 
-	createDatabaseCmd.Flags().StringP(RELEASE_VERSION, "v", DEFAULT_CREATE_DATABASE_RELEASE_VERSION, "Database version to deploy")
-	createDatabaseCmd.Flags().StringP(TOPOLOGY, "t", DEFAULT_CREATE_DATABASE_TOPOLOGY, "Database topology to select")
-	createDatabaseCmd.Flags().StringP(SIZE, "s", DEFAULT_CREATE_DATABASE_SIZE, "Size of the nodes running the database")
-	createDatabaseCmd.Flags().StringP(STORAGE, "g", DEFAULT_CREATE_DATABASE_TXSTORAGE, "Size of the persistent storage disk")
-	createDatabaseCmd.Flags().StringP(MAXSCALE_CONFIG, "m", DEFAULT_CREATE_DATABASE_MAXSCALE_CONFIG, "Configurations for maxscale")
-	createDatabaseCmd.Flags().StringP(NAME, "n", DEFAULT_CREATE_DATABASE_NAME, "Name used to identify the database")
-	createDatabaseCmd.Flags().StringP(REGION, "r", DEFAULT_CREATE_DATABASE_REGION, "Geographic region to deploy the database")
-	createDatabaseCmd.Flags().String(REPL_REGION, DEFAULT_CREATE_DATABASE_REPL_REGION, "Replica region for the database")
-	createDatabaseCmd.Flags().StringP(PROVIDER, "p", DEFAULT_CREATE_DATABASE_PROVIDER, "Cloud provider to host the database")
-	createDatabaseCmd.Flags().String(REPLICAS, DEFAULT_CREATE_DATABASE_REPLICAS, "Number of replicas to deploy")
-	createDatabaseCmd.Flags().String(MONITOR, DEFAULT_CREATE_DATABASE_MONITOR, "Whether to deploy a monitoring cluster alongside the database")
-	createDatabaseCmd.Flags().String(MAXSCALE_PROXY, DEFAULT_CREATE_DATABASE_MAXSCALE_PROXY, "Whether to set up a proxy for maxscale")
-	createDatabaseCmd.Flags().String(VOLUME_IOPS, DEFAULT_CREATE_DATABASE_VOLUME_IOPS, "Amount of IOPS for the volume (e.g. 100). Required for Amazon AWS")
-	createDatabaseCmd.Flags().String(VOLUME_TYPE, DEFAULT_CREATE_DATABASE_VOLUME_TYPE, "Type of volume to use (e.g. io1, gp3). Required for Amazon AWS")
-	createDatabaseCmd.Flags().String(TIER, DEFAULT_CREATE_DATABASE_VOLUME_TYPE, fmt.Sprintf("%s in which to provision %s", strings.ToTitle(TIER), DATABASE))
+	createServiceCmd.Flags().StringP(RELEASE_VERSION, "v", DEFAULT_CREATE_SERVICE_RELEASE_VERSION, "Release version to deploy")
+	createServiceCmd.Flags().StringP(TOPOLOGY, "t", DEFAULT_CREATE_SERVICE_TOPOLOGY, "Service topology to select")
+	createServiceCmd.Flags().StringP(SIZE, "s", DEFAULT_CREATE_SERVICE_SIZE, "Size of the nodes running the service")
+	createServiceCmd.Flags().StringP(STORAGE, "g", DEFAULT_CREATE_SERVICE_TXSTORAGE, "Size of the persistent storage disk")
+	createServiceCmd.Flags().StringP(MAXSCALE_CONFIG, "m", DEFAULT_CREATE_SERVICE_MAXSCALE_CONFIG, "Configurations for maxscale")
+	createServiceCmd.Flags().StringP(NAME, "n", DEFAULT_CREATE_SERVICE_NAME, "Name used to identify the service")
+	createServiceCmd.Flags().StringP(REGION, "r", DEFAULT_CREATE_SERVICE_REGION, "Geographic region to deploy the service")
+	createServiceCmd.Flags().String(REPL_REGION, DEFAULT_CREATE_SERVICE_REPL_REGION, "Replica region for the service")
+	createServiceCmd.Flags().StringP(PROVIDER, "p", DEFAULT_CREATE_SERVICE_PROVIDER, "Cloud provider to host the service")
+	createServiceCmd.Flags().String(REPLICAS, DEFAULT_CREATE_SERVICE_REPLICAS, "Number of replicas to deploy")
+	createServiceCmd.Flags().String(MONITOR, DEFAULT_CREATE_SERVICE_MONITOR, "Whether to deploy a monitoring cluster alongside the service")
+	createServiceCmd.Flags().String(MAXSCALE_PROXY, DEFAULT_CREATE_SERVICE_MAXSCALE_PROXY, "Whether to set up a proxy for maxscale")
+	createServiceCmd.Flags().String(VOLUME_IOPS, DEFAULT_CREATE_SERVICE_VOLUME_IOPS, "Amount of IOPS for the volume (e.g. 100). Required for Amazon AWS")
+	createServiceCmd.Flags().String(VOLUME_TYPE, DEFAULT_CREATE_SERVICE_VOLUME_TYPE, "Type of volume to use (e.g. io1, gp3). Required for Amazon AWS")
+	createServiceCmd.Flags().String(TIER, DEFAULT_CREATE_SERVICE_VOLUME_TYPE, fmt.Sprintf("%s in which to provision %s", strings.ToTitle(TIER), SERVICE))
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	deleteValidArgs = []string{DATABASE}
+	deleteValidArgs = []string{SERVICE}
 	deleteCmd       = &cobra.Command{
 		Use:       DELETE,
 		Short:     "Delete a resource in MariaDB SkySQL",

--- a/cmd/delete_allowed_address.go
+++ b/cmd/delete_allowed_address.go
@@ -10,18 +10,18 @@ import (
 
 var (
 	deleteAllowedAddressCmd = &cobra.Command{
-		Use:   fmt.Sprintf("%s [%s] [%s]", ALLOWED_ADDRESS, strings.ToUpper(DATABASE), strings.ToUpper(ALLOWED_ADDRESS)),
-		Short: fmt.Sprintf("Delete an %s from a %s", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), DATABASE),
-		Long:  fmt.Sprintf("Deletes an %s for user on %s in MariaDB SkySQL.", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), DATABASE),
+		Use:   fmt.Sprintf("%s [%s] [%s]", ALLOWED_ADDRESS, strings.ToUpper(SERVICE), strings.ToUpper(ALLOWED_ADDRESS)),
+		Short: fmt.Sprintf("Delete an %s from a %s", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), SERVICE),
+		Long:  fmt.Sprintf("Deletes an %s for user on %s in MariaDB SkySQL.", strings.Replace(ALLOWED_ADDRESS, "-", " ", -1), SERVICE),
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			databaseId := string(args[0])
+			serviceID := string(args[0])
 			ipAddress := string(args[1])
 			reqQuery := skysql.RemoveAllowedAddressParams{
 				Address: &ipAddress,
 			}
 
-			res, err := client.RemoveAllowedAddress(cmd.Context(), databaseId, &reqQuery)
+			res, err := client.RemoveAllowedAddress(cmd.Context(), serviceID, &reqQuery)
 			checkAndPrint(res, err, ALLOWED_ADDRESS)
 		},
 	}

--- a/cmd/delete_configuration.go
+++ b/cmd/delete_configuration.go
@@ -10,8 +10,8 @@ import (
 var (
 	deleteConfigurationCmd = &cobra.Command{
 		Use:   fmt.Sprintf("%s [%s]", CONFIGURATION, strings.ToUpper(CONFIGURATION)),
-		Short: fmt.Sprintf("Delete a %s %s", DATABASE, CONFIGURATION),
-		Long:  fmt.Sprintf("Deletes a %s %s for user in MariaDB SkySQL.", DATABASE, CONFIGURATION),
+		Short: fmt.Sprintf("Delete a %s %s", SERVICE, CONFIGURATION),
+		Long:  fmt.Sprintf("Deletes a %s %s for user in MariaDB SkySQL.", SERVICE, CONFIGURATION),
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			configNumber := string(args[0])

--- a/cmd/delete_database.go
+++ b/cmd/delete_database.go
@@ -5,21 +5,21 @@ import (
 )
 
 var (
-	deleteDatabaseCmd = &cobra.Command{
-		Use:   DATABASE + " [DATABASE]",
-		Short: "Delete an existing database",
-		Long:  "Submits request to MariaDB SkySQL to delete an existing database. " + HINT_DB_ID,
+	deleteServiceCmd = &cobra.Command{
+		Use:   SERVICE + " [SERVICE]",
+		Short: "Delete an existing service",
+		Long:  "Submits request to MariaDB SkySQL to delete an existing service. " + HINT_SVC_ID,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			dbid := args[0]
+			svcid := args[0]
 
-			res, err := client.DeleteDatabase(cmd.Context(), dbid)
+			res, err := client.DeleteService(cmd.Context(), svcid)
 
-			checkAndPrint(res, err, DATABASES)
+			checkAndPrint(res, err, SERVICES)
 		},
 	}
 )
 
 func init() {
-	deleteCmd.AddCommand(deleteDatabaseCmd)
+	deleteCmd.AddCommand(deleteServiceCmd)
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	getValidArgs  = []string{DATABASES, QUOTAS}
-	getArgAliases = []string{DATABASE, QUOTA}
+	getValidArgs  = []string{SERVICES, QUOTAS}
+	getArgAliases = []string{SERVICE, QUOTA}
 	getCmd        = &cobra.Command{
 		Use:        GET,
 		Short:      "Query MariaDB SkySQL for resource information",

--- a/cmd/get_allowlist.go
+++ b/cmd/get_allowlist.go
@@ -4,23 +4,23 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mariadb-corporation/skysql-api-go"
+	skysql "github.com/mariadb-corporation/skysql-api-go"
 	"github.com/spf13/cobra"
 )
 
 var (
 	getAllowlistCmd = &cobra.Command{
-		Use:   fmt.Sprintf("%s [%s]", ALLOWLIST, strings.ToUpper(DATABASE)),
-		Short: fmt.Sprintf("Retrieve list of allowed IPs for a %s", DATABASE),
-		Long:  fmt.Sprintf("Queries for list of allowed IP addresses for a specific %s", DATABASE),
+		Use:   fmt.Sprintf("%s [%s]", ALLOWLIST, strings.ToUpper(SERVICE)),
+		Short: fmt.Sprintf("Retrieve list of allowed IPs for a %s", SERVICE),
+		Long:  fmt.Sprintf("Queries for list of allowed IP addresses for a specific %s", SERVICE),
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
-				crash(fmt.Sprintf("Missing required %s ID", DATABASE))
+				crash(fmt.Sprintf("Missing required %s ID", SERVICE))
 			}
 
-			dbid := args[0]
-			res, err := client.ListAllowedAddresses(cmd.Context(), dbid, &skysql.ListAllowedAddressesParams{})
+			svcid := args[0]
+			res, err := client.ListAllowedAddresses(cmd.Context(), svcid, &skysql.ListAllowedAddressesParams{})
 			checkAndPrint(res, err, ALLOWLIST)
 		},
 	}

--- a/cmd/get_configurations.go
+++ b/cmd/get_configurations.go
@@ -14,8 +14,8 @@ var (
 	getConfigurationCmd = &cobra.Command{
 		Use:     fmt.Sprintf("%s [%s]", CONFIGURATIONS, strings.ToUpper(CONFIGURATION)),
 		Aliases: []string{CONFIGURATION},
-		Short:   fmt.Sprintf("Retrieve stored %s %s", DATABASE, CONFIGURATIONS),
-		Long:    fmt.Sprintf("Retrieves one or more custom %s %s owned by the user", DATABASE, CONFIGURATIONS),
+		Short:   fmt.Sprintf("Retrieve stored %s %s", SERVICE, CONFIGURATIONS),
+		Long:    fmt.Sprintf("Retrieves one or more custom %s %s owned by the user", SERVICE, CONFIGURATIONS),
 		Args:    cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var res *http.Response

--- a/cmd/get_databases.go
+++ b/cmd/get_databases.go
@@ -11,29 +11,29 @@ import (
 )
 
 var (
-	getDatabaseCmd = &cobra.Command{
-		Use:     fmt.Sprintf("%s [%s]", DATABASES, strings.ToUpper(DATABASE)),
-		Aliases: []string{DATABASE},
-		Short:   "Retrieve database information",
-		Long:    "Queries for information about deployed database resources in SkySQL. " + HINT_DB_ID,
+	getServiceCmd = &cobra.Command{
+		Use:     fmt.Sprintf("%s [%s]", SERVICES, strings.ToUpper(SERVICE)),
+		Aliases: []string{SERVICE},
+		Short:   "Retrieve service information",
+		Long:    "Queries for information about deployed service resources in SkySQL. " + HINT_SVC_ID,
 		Args:    cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var res *http.Response
 			var err error
 			if len(args) == 1 {
-				dbid := args[0]
-				res, err = client.ReadDatabase(cmd.Context(), dbid)
+				svcid := args[0]
+				res, err = client.ReadService(cmd.Context(), svcid)
 			} else {
 				limit := viper.GetInt("limit")
-				res, err = client.ListDatabases(cmd.Context(), &skysql.ListDatabasesParams{
+				res, err = client.ListServices(cmd.Context(), &skysql.ListServicesParams{
 					Limit: &limit,
 				})
 			}
-			checkAndPrint(res, err, DATABASES)
+			checkAndPrint(res, err, SERVICES)
 		},
 	}
 )
 
 func init() {
-	getCmd.AddCommand(getDatabaseCmd)
+	getCmd.AddCommand(getServiceCmd)
 }

--- a/cmd/get_status.go
+++ b/cmd/get_status.go
@@ -10,16 +10,16 @@ import (
 
 var (
 	getStatusCmd = &cobra.Command{
-		Use:   fmt.Sprintf("%s [%s]", STATUS, strings.ToUpper(DATABASE)),
-		Short: fmt.Sprintf("Get current %s for a %s", STATUS, DATABASE),
-		Long:  fmt.Sprintf("Get the current %s of a %s in MariaDB SkySQL", STATUS, DATABASE),
+		Use:   fmt.Sprintf("%s [%s]", STATUS, strings.ToUpper(SERVICE)),
+		Short: fmt.Sprintf("Get current %s for a %s", STATUS, SERVICE),
+		Long:  fmt.Sprintf("Get the current %s of a %s in MariaDB SkySQL", STATUS, SERVICE),
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			databaseId := args[0]
+			serviceID := args[0]
 
 			var res *http.Response
 			var err error
-			res, err = client.ReadStatus(cmd.Context(), databaseId)
+			res, err = client.ReadStatus(cmd.Context(), serviceID)
 
 			checkAndPrint(res, err, STATUS)
 		},

--- a/cmd/get_topologies.go
+++ b/cmd/get_topologies.go
@@ -13,8 +13,8 @@ var (
 	getTopologyCmd = &cobra.Command{
 		Use:     TOPOLOGIES,
 		Aliases: []string{TOPOLOGY},
-		Short:   fmt.Sprintf("Retrieve list of MariaDB SkySQL %s %s", DATABASE, TOPOLOGIES),
-		Long:    fmt.Sprintf("Retrieves list of %s %s available for use with MariaDB SkySQL", DATABASE, TOPOLOGIES),
+		Short:   fmt.Sprintf("Retrieve list of MariaDB SkySQL %s %s", SERVICE, TOPOLOGIES),
+		Long:    fmt.Sprintf("Retrieves list of %s %s available for use with MariaDB SkySQL", SERVICE, TOPOLOGIES),
 		Args:    cobra.NoArgs,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag(PRODUCT, cmd.PersistentFlags().Lookup(PRODUCT))

--- a/cmd/get_versions.go
+++ b/cmd/get_versions.go
@@ -13,8 +13,8 @@ var (
 	getVersionCmd = &cobra.Command{
 		Use:     VERSIONS,
 		Aliases: []string{VERSION},
-		Short:   fmt.Sprintf("Retrieve list of MariaDB SkySQL %s %s", DATABASE, VERSIONS),
-		Long:    fmt.Sprintf("Retrieves list of %s %s available for use with MariaDB SkySQL", DATABASE, VERSIONS),
+		Short:   fmt.Sprintf("Retrieve list of MariaDB SkySQL %s %s", SERVICE, VERSIONS),
+		Long:    fmt.Sprintf("Retrieves list of %s %s available for use with MariaDB SkySQL", SERVICE, VERSIONS),
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			limit := viper.GetInt(LIMIT)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,11 +74,11 @@ var (
 				crash("required flag \"api-key\" not set " + cmd.Use)
 			}
 
-			mdbid := viper.GetString("mdbid")
-			url, err := url.Parse(mdbid)
-			checkErr(err, "unable to parse mdbid url")
+			msvcid := viper.GetString("msvcid")
+			url, err := url.Parse(msvcid)
+			checkErr(err, "unable to parse msvcid url")
 			if url.String() == "" {
-				checkErr(url, "unable to parse mdbid url")
+				checkErr(url, "unable to parse msvcid url")
 			}
 			url.Path = path.Join(url.Path, "/api/v1/token")
 
@@ -130,11 +130,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default $HOME/.skysqlcli.yaml)")
 	rootCmd.PersistentFlags().String("api-key", "", "Long-lived JWT issued from MariaDB ID")
 	rootCmd.PersistentFlags().String("host", SKYSQL_API, "URL for the SkySQL API")
-	rootCmd.PersistentFlags().String("mdbid", MARIADB_ID, "URL for MariaDB ID")
+	rootCmd.PersistentFlags().String("msvcid", MARIADB_ID, "URL for MariaDB ID")
 
 	viper.BindPFlag("api_key", rootCmd.PersistentFlags().Lookup("api-key"))
 	viper.BindPFlag("host", rootCmd.PersistentFlags().Lookup("host"))
-	viper.BindPFlag("mdbid", rootCmd.PersistentFlags().Lookup("mdbid"))
+	viper.BindPFlag("msvcid", rootCmd.PersistentFlags().Lookup("msvcid"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	updateValidArgs = []string{DATABASE}
+	updateValidArgs = []string{SERVICE}
 	updateCmd       = &cobra.Command{
 		Use:       UPDATE,
 		Short:     "Update a resource in MariaDB SkySQL",

--- a/cmd/update_database.go
+++ b/cmd/update_database.go
@@ -7,29 +7,29 @@ import (
 )
 
 var (
-	updateDatabaseCmd = &cobra.Command{
-		Use:   DATABASE + " [DATABASE]",
-		Short: "Update an existing database",
-		Long:  "Submits request to MariaDB SkySQL to update an existing database. " + HINT_DB_ID,
+	updateServiceCmd = &cobra.Command{
+		Use:   SERVICE + " [SERVICE]",
+		Short: "Update an existing service",
+		Long:  "Submits request to MariaDB SkySQL to update an existing service. " + HINT_SVC_ID,
 		Args:  cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag(NAME, cmd.Flags().Lookup(NAME))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			dbid := args[0]
-			reqBody := skysql.UpdateDatabaseJSONRequestBody{
+			svcid := args[0]
+			reqBody := skysql.UpdateServiceJSONRequestBody{
 				Name: viper.GetString(NAME),
 			}
 
-			res, err := client.UpdateDatabase(cmd.Context(), dbid, reqBody)
+			res, err := client.UpdateService(cmd.Context(), svcid, reqBody)
 
-			checkAndPrint(res, err, DATABASES)
+			checkAndPrint(res, err, SERVICES)
 		},
 	}
 )
 
 func init() {
-	updateCmd.AddCommand(updateDatabaseCmd)
+	updateCmd.AddCommand(updateServiceCmd)
 
-	updateDatabaseCmd.Flags().StringP(NAME, "n", DEFAULT_UPDATE_DATABASE_NAME, "Name used to identify the database")
+	updateServiceCmd.Flags().StringP(NAME, "n", DEFAULT_UPDATE_SERVICE_NAME, "Name used to identify the service")
 }

--- a/cmd/update_status.go
+++ b/cmd/update_status.go
@@ -11,23 +11,23 @@ import (
 
 var (
 	updateStatusCmd = &cobra.Command{
-		Use:   fmt.Sprintf("%s [%s] [Start|Stop]", STATUS, strings.ToUpper(DATABASE)),
-		Short: fmt.Sprintf("Update %s for %s", STATUS, DATABASE),
-		Long:  fmt.Sprintf("Updates %s for %s belonging user in MariaDB SkySQL.", STATUS, DATABASE),
+		Use:   fmt.Sprintf("%s [%s] [Start|Stop]", STATUS, strings.ToUpper(SERVICE)),
+		Short: fmt.Sprintf("Update %s for %s", STATUS, SERVICE),
+		Long:  fmt.Sprintf("Updates %s for %s belonging user in MariaDB SkySQL.", STATUS, SERVICE),
 		Args:  cobra.ExactArgs(2),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag(NAME, cmd.Flags().Lookup(NAME))
 			viper.BindPFlag(CONFIG_JSON, cmd.Flags().Lookup(CONFIG_JSON))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			databaseId := args[0]
+			serviceID := args[0]
 			status := args[1]
 
 			reqBody := skysql.UpdateStatusJSONRequestBody{
 				Action: status,
 			}
 
-			res, err := client.UpdateStatus(cmd.Context(), databaseId, reqBody)
+			res, err := client.UpdateStatus(cmd.Context(), serviceID, reqBody)
 
 			checkAndPrint(res, err, STATUS)
 		},

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/deepmap/oapi-codegen v1.8.2
-	github.com/mariadb-corporation/skysql-api-go v0.0.9
+	github.com/mariadb-corporation/skysql-api-go v0.0.12
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mariadb-corporation/skysql-api-go v0.0.9 h1:6u2MqzPS99D8TLl+tzEfSzSlEDWrx8/pn4joT1vZi0E=
-github.com/mariadb-corporation/skysql-api-go v0.0.9/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
+github.com/mariadb-corporation/skysql-api-go v0.0.12 h1:yHMz3yVR60+AJZaNNeFuFIgqvH42+4tmoR32VnT2t7k=
+github.com/mariadb-corporation/skysql-api-go v0.0.12/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
Turns out that it was decided several years ago to refer to these
entities as services rather than databases, so this change is an
update to the command line client to bring it in line with the related
update in the API.

DBAAS-8186

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [ ] `bugfix`
- [x] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
