### PR TITLE
Rename msvcid flag back to mdbid

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,11 +74,11 @@ var (
 				crash("required flag \"api-key\" not set " + cmd.Use)
 			}
 
-			msvcid := viper.GetString("msvcid")
-			url, err := url.Parse(msvcid)
-			checkErr(err, "unable to parse msvcid url")
+			mdbid := viper.GetString("mdbid")
+			url, err := url.Parse(mdbid)
+			checkErr(err, "unable to parse mdbid url")
 			if url.String() == "" {
-				checkErr(url, "unable to parse msvcid url")
+				checkErr(url, "unable to parse mdbid url")
 			}
 			url.Path = path.Join(url.Path, "/api/v1/token")
 
@@ -130,11 +130,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default $HOME/.skysqlcli.yaml)")
 	rootCmd.PersistentFlags().String("api-key", "", "Long-lived JWT issued from MariaDB ID")
 	rootCmd.PersistentFlags().String("host", SKYSQL_API, "URL for the SkySQL API")
-	rootCmd.PersistentFlags().String("msvcid", MARIADB_ID, "URL for MariaDB ID")
+	rootCmd.PersistentFlags().String("mdbid", MARIADB_ID, "URL for MariaDB ID")
 
 	viper.BindPFlag("api_key", rootCmd.PersistentFlags().Lookup("api-key"))
 	viper.BindPFlag("host", rootCmd.PersistentFlags().Lookup("host"))
-	viper.BindPFlag("msvcid", rootCmd.PersistentFlags().Lookup("msvcid"))
+	viper.BindPFlag("mdbid", rootCmd.PersistentFlags().Lookup("mdbid"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
I got a little overzealous on my rename of database to service, and
accidentally picked up `mdbid` as needing to be changed to `msvcid`.
This is a commit to change it back to represent MariaDB ID.

DBAAS-8186

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [x] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
