### PR TITLE
Add `ssl_tls` field to create service requests

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -44,6 +44,7 @@ const (
 	SIZE            = "size"
 	SIZES           = "sizes"
 	STATUS          = "status"
+	SSL_TLS         = "ssl-tls"
 	STORAGE         = "storage"
 	TIER            = "tier"
 	TIERS           = "tiers"
@@ -77,6 +78,8 @@ const (
 	DEFAULT_CREATE_SERVICE_MAXSCALE_PROXY  = "false"
 	DEFAULT_CREATE_SERVICE_VOLUME_IOPS     = ""
 	DEFAULT_CREATE_SERVICE_VOLUME_TYPE     = ""
+	DEFAULT_CREATE_SERVICE_TIER            = ""
+	DEFAULT_CREATE_SERVICE_SSL_TLS         = "Enabled"
 
 	DEFAULT_UPDATE_SERVICE_NAME = ""
 

--- a/cmd/create_database.go
+++ b/cmd/create_database.go
@@ -38,23 +38,25 @@ var (
 			monitor := viper.GetString(MONITOR)
 			maxscaleProxy := viper.GetString(MAXSCALE_PROXY)
 			volumeIOPS := viper.GetString(VOLUME_IOPS)
-			volumeType := viper.GetString(VOLUME_TYPE)
+			volumeType := skysql.ServiceInVolumeType(viper.GetString(VOLUME_TYPE))
+			ssltls := skysql.ServiceInSslTls(viper.GetString(SSL_TLS))
 			reqBody := skysql.CreateServiceJSONRequestBody{
 				ReleaseVersion: viper.GetString(RELEASE_VERSION),
-				Topology:       viper.GetString(TOPOLOGY),
+				Topology:       skysql.ServiceInTopology(viper.GetString(TOPOLOGY)),
 				Size:           viper.GetString(SIZE),
 				TxStorage:      viper.GetString(STORAGE),
 				MaxscaleConfig: &maxscaleConfig,
 				Name:           viper.GetString(NAME),
 				Region:         viper.GetString(REGION),
 				ReplRegion:     &replRegion,
-				Provider:       viper.GetString(PROVIDER),
+				Provider:       skysql.ServiceInProvider(viper.GetString(PROVIDER)),
 				Replicas:       viper.GetString(REPLICAS),
 				Monitor:        &monitor,
 				MaxscaleProxy:  &maxscaleProxy,
 				VolumeIops:     &volumeIOPS,
 				VolumeType:     &volumeType,
-				Tier:           viper.GetString(TIER),
+				Tier:           skysql.ServiceInTier(viper.GetString(TIER)),
+				SslTls:         &ssltls,
 			}
 
 			res, err := client.CreateService(cmd.Context(), reqBody)
@@ -81,5 +83,6 @@ func init() {
 	createServiceCmd.Flags().String(MAXSCALE_PROXY, DEFAULT_CREATE_SERVICE_MAXSCALE_PROXY, "Whether to set up a proxy for maxscale")
 	createServiceCmd.Flags().String(VOLUME_IOPS, DEFAULT_CREATE_SERVICE_VOLUME_IOPS, "Amount of IOPS for the volume (e.g. 100). Required for Amazon AWS")
 	createServiceCmd.Flags().String(VOLUME_TYPE, DEFAULT_CREATE_SERVICE_VOLUME_TYPE, "Type of volume to use (e.g. io1, gp3). Required for Amazon AWS")
-	createServiceCmd.Flags().String(TIER, DEFAULT_CREATE_SERVICE_VOLUME_TYPE, fmt.Sprintf("%s in which to provision %s", strings.ToTitle(TIER), SERVICE))
+	createServiceCmd.Flags().String(TIER, DEFAULT_CREATE_SERVICE_TIER, fmt.Sprintf("%s in which to provision %s", strings.Title(TIER), SERVICE))
+	createServiceCmd.Flags().String(SSL_TLS, DEFAULT_CREATE_SERVICE_SSL_TLS, "Specify whether to use SSL/TLS encryption")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/deepmap/oapi-codegen v1.8.2
-	github.com/mariadb-corporation/skysql-api-go v0.0.12
+	github.com/mariadb-corporation/skysql-api-go v0.0.15
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mariadb-corporation/skysql-api-go v0.0.12 h1:yHMz3yVR60+AJZaNNeFuFIgqvH42+4tmoR32VnT2t7k=
-github.com/mariadb-corporation/skysql-api-go v0.0.12/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
+github.com/mariadb-corporation/skysql-api-go v0.0.15 h1:dQol2FgP5tMhlXNCMde+tD5MCjRfvBiHdcogfLYsNmg=
+github.com/mariadb-corporation/skysql-api-go v0.0.15/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
This way users can enable or disable tls for their service. I left the
default as enabled since hopefully no one will ever use this flag...

DBAAS-8302

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [ ] `bugfix`
- [x] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
