### PR TITLE
Use kebab case for api-key flag in config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ var (
 				return
 			}
 
-			apiKey := viper.GetString("api_key")
+			apiKey := viper.GetString("api-key")
 			if apiKey == "" {
 				crash("required flag \"api-key\" not set " + cmd.Use)
 			}
@@ -132,7 +132,7 @@ func init() {
 	rootCmd.PersistentFlags().String("host", SKYSQL_API, "URL for the SkySQL API")
 	rootCmd.PersistentFlags().String("mdbid", MARIADB_ID, "URL for MariaDB ID")
 
-	viper.BindPFlag("api_key", rootCmd.PersistentFlags().Lookup("api-key"))
+	viper.BindPFlag("api-key", rootCmd.PersistentFlags().Lookup("api-key"))
 	viper.BindPFlag("host", rootCmd.PersistentFlags().Lookup("host"))
 	viper.BindPFlag("mdbid", rootCmd.PersistentFlags().Lookup("mdbid"))
 }


### PR DESCRIPTION
To be clear, no one should be putting a plaintext private api key into
the config file as that is a _bad idea_ from a security perspective.

But, for consistency sake, that flag uses kebab case not snake case, so
the viper lookup should follow along. The environment variable will
still work as intended, as we have the `SetEnvKeyReplacer` already set
up to swap out dashes for low dashes for the environment variables.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [x] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
