### PR TITLE
Fix auto version included in go build of cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,21 @@ jobs:
         with:
           path: ${{ matrix.artifact }}
           key: ${{ matrix.name }}-binary-${{ github.sha }}
+      - id: auto_version # https://github.com/intuit/auto/issues/2062
+        name: Get version bump type
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION_TYPE=$(auto version) && echo "VERSION_TYPE=${VERSION_TYPE}" >> "${GITHUB_ENV}"
+      - id: compute_tag
+        name: Compute next tag
+        uses: craig-day/compute-tag@v10
+        with:
+          github_token: ${{ github.token }}
+          version_type: ${{ env.VERSION_TYPE }}
       - name: Build
         run: |
-          go build -ldflags "-X github.com/mariadb-corporation/skysqlcli/cmd.Version=$(auto release -d | grep -Po ' Would have created a release on GitHub for version: \K[^ ]+')" -o ${{ matrix.artifact }} .
+          go build -ldflags "-X github.com/mariadb-corporation/skysqlcli/cmd.Version=${{ steps.compute_tag.outputs.next_tag }}" -o ${{ matrix.artifact }} .
   release:
     name: Publish new release
     runs-on: ubuntu-latest


### PR DESCRIPTION
What I have there still works locally, but apparently it isn't working
in the github actions workflow.

I saw someone else having the same trouble over in the github issues for
intuit/auto, so I'm following the pattern they used for a workaround to
hopefully address the issue.

https://github.com/intuit/auto/issues/2062#issue-979861914

I don't have a good way to test this, other than to merge and find out,
without doing a lot of changes to the pipeline. Hopefully this works as
is, but if it doesn't then I'll go back and find a way to test so that
everyone isn't pestered by me working on the pipeline.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [x] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
