### PR TITLE
Install additional plugins for `intuit/auto` in build pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           go-version: 1.17
       - name: Install Auto
-        run : npm i -g auto
+        run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels
       - name: Configure git for private repos
         run : |
           git config --global url."https://${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/mariadb-corporation".insteadOf "https://github.com/mariadb-corporation"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,7 @@ var (
 		Short:     "CLI client to interact with the SkySQL API",
 		Long:      `A command line tool for managing resources deployed into MariaDB SkySQL`,
 		ValidArgs: validArgs,
+		Version:   Version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if _, ok := skipAuth[cmd.Use]; ok {
 				return


### PR DESCRIPTION
Yikes - so we have that install for auto happen twice in the pipeline,
and in that build job we didn't include the plugins. I really with
gh-actions gave us more to work with for deduping this kind of stuff.

At some point I guess we'll have to start writing custom actions.

I also noticed in the cobra docs that if you populate the version prop
then it adds a `--version` flag to the root command which is nice.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [x] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
