### PR TITLE
Determine version info at start of pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,35 @@ on:
     branches:
       - main
 jobs:
+  version-info:
+    name: Version info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute_tag.outputs.next_tag }}
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+        with: # https://stackoverflow.com/a/65081720
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: "0"
+      - name: Install Auto
+        run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels
+      - id: auto_version # https://github.com/intuit/auto/issues/2062
+        name: Get version bump type
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION_TYPE=$(auto version) && echo "VERSION_TYPE=${VERSION_TYPE}" >> "${GITHUB_ENV}"
+      - id: compute_tag
+        name: Compute next tag
+        uses: craig-day/compute-tag@v10
+        with:
+          github_token: ${{ github.token }}
+          version_type: ${{ env.VERSION_TYPE }}
   artifacts:
     name: Build artifacts
     runs-on: ${{ matrix.os }}
+    needs: version-info
     env:
       GOPRIVATE: github.com/mariadb-corporation
     strategy:
@@ -32,8 +58,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      - name: Install Auto
-        run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels
       - name: Configure git for private repos
         run : |
           git config --global url."https://${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/mariadb-corporation".insteadOf "https://github.com/mariadb-corporation"
@@ -49,23 +73,15 @@ jobs:
         with:
           path: ${{ matrix.artifact }}
           key: ${{ matrix.name }}-binary-${{ github.sha }}
-      - id: auto_version # https://github.com/intuit/auto/issues/2062
-        name: Get version bump type
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION_TYPE=$(auto version) && echo "VERSION_TYPE=${VERSION_TYPE}" >> "${GITHUB_ENV}"
-      - id: compute_tag
-        name: Compute next tag
-        uses: craig-day/compute-tag@v10
-        with:
-          github_token: ${{ github.token }}
-          version_type: ${{ env.VERSION_TYPE }}
       - name: Build
         run: |
-          go build -ldflags "-X github.com/mariadb-corporation/skysqlcli/cmd.Version=${{ steps.compute_tag.outputs.next_tag }}" -o ${{ matrix.artifact }} .
+          go build -ldflags "-X github.com/mariadb-corporation/skysqlcli/cmd.Version=${{ needs.version-info.outputs.version }}" -o ${{ matrix.artifact }} .
+      - name: Log version
+        run: |
+          ./${{ matrix.artifact }} --version
   release:
     name: Publish new release
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [artifacts]
     outputs:


### PR DESCRIPTION
I pulled out the auto usage from the build matrix because it was doing
the same thing in each of those three jobs, and due to them being
different environments it ran into trouble with windows.

I figure since it's the same information, just calculate it once and pass
the value along to the build jobs.

I also went ahead and added a conditional on the release job, that way
we can just add the branch we're working on to the list of branches at
the top and test out the build without accidentally making a release.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [x] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
