### PR TITLE
Generate cli docs as md, yaml, rst, and man pages

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -2,6 +2,12 @@
   "plugins": [
     "git-tag",
     "pr-body-labels",
+    [
+      "exec",
+      {
+        "beforeCommitChangelog": "make docs"
+      }
+    ],
     ["upload-assets", ["./skysqlcli-linux", "./skysqlcli-macos", "./skysqlcli-windows.exe"]]
   ],
   "owner": "mariadb-corporation",

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ ENV GOPRIVATE=github.com/mariadb-corporation
 ENV GO111MODULE=on
 
 # [Optional] Uncomment the next line to use go get to install anything else you need
-RUN npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels && \
+RUN npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels @auto-it/exec && \
     git config --global url."ssh://git@github.com:".insteadOf "https://github.com/" && \
     go get github.com/spf13/cobra/cobra && \
     chown -R vscode /go/pkg && \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: "0"
       - name: Install Auto
-        run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels
+        run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels @auto-it/exec
       - id: auto_version # https://github.com/intuit/auto/issues/2062
         name: Get version bump type
         env:
@@ -93,7 +93,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: "0"
       - name: Install Auto
-        run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels
+        run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels @auto-it/exec
       - name: linux binary
         id: linux-binary
         uses: actions/cache@v2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY = deps
+.PHONY: deps docs
 
 deps:
 	go mod tidy
+
+docs:
+	go run docs/main.go

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To view the commands that are available, use...
 skysqlcli --help
 ```
 
+The usage information is also [available in markdown form in the repository](docs/md/skysqlcli.md).
+
 ### Configuration
 
 Environment variables read by this cli client are all prefixed with `SKYSQL_`, and use the same flags as the command line with any hyphens replaced with underscores and using uppercase. For example, to provide the `--api-key` flag via an environment variable, export the value using `SKYSQL_API_KEY`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -163,3 +163,7 @@ func initConfig() {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 }
+
+func SkySQLCLICommand() *cobra.Command {
+	return rootCmd
+}

--- a/docs/main.go
+++ b/docs/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"log"
+
+	"github.com/mariadb-corporation/skysqlcli/cmd"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	rootCmd := cmd.SkySQLCLICommand()
+	rootCmd.DisableAutoGenTag = true
+	err := doc.GenMarkdownTree(rootCmd, "./docs/md/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = doc.GenYamlTree(rootCmd, "./docs/yaml/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = doc.GenReSTTree(rootCmd, "./docs/rst/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = doc.GenManTree(rootCmd, &doc.GenManHeader{
+		Title:   "SkySQL CLI Client",
+		Source:  "MariaDB Corporation",
+		Section: "3",
+	}, "./docs/man/")
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docs/man/skysqlcli-create-allowed-address.3
+++ b/docs/man/skysqlcli-create-allowed-address.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-create\-allowed\-address \- Add a new allowed address to a service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli create allowed\-address [SERVICE] [IP\-ADDRESS] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Adds a new allowed address for service in MariaDB SkySQL.
+
+
+.SH OPTIONS
+.PP
+\fB\-\-comment\fP=""
+	Additional comment to help identify address
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for allowed\-address
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-create(3)\fP

--- a/docs/man/skysqlcli-create-configuration.3
+++ b/docs/man/skysqlcli-create-configuration.3
@@ -1,0 +1,57 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-create\-configuration \- Create a new configuration
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli create configuration [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Creates a new configuration for user in MariaDB SkySQL.
+
+
+.SH OPTIONS
+.PP
+\fB\-j\fP, \fB\-\-config\-json\fP="\\n\\t\\t{\\n\\t\\t\\t\\"variables\\": {\\n\\t\\t\\t\\t\\"interactive\_timeout\\": {\\n\\t\\t\\t\\t\\t\\"type\\": \\"number\\",\\n\\t\\t\\t\\t\\t\\"value\\": \\"300\\",\\n\\t\\t\\t\\t\\t\\"requires\_restart\\": true,\\n\\t\\t\\t\\t\\t\\"regex\\": \\"\\"\\n\\t\\t\\t\\t}\\n\\t\\t\\t}\\n\\t\\t}\\n\\t"
+	JSON object containing configuration
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for configuration
+
+.PP
+\fB\-n\fP, \fB\-\-name\fP="HA"
+	Name used to identify the configuration
+
+.PP
+\fB\-t\fP, \fB\-\-topology\fP="Primary/Replica"
+	Configuration topology to select
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-create(3)\fP

--- a/docs/man/skysqlcli-create-service.3
+++ b/docs/man/skysqlcli-create-service.3
@@ -1,0 +1,109 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-create\-service \- Create a new service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli create service [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Submits request to MariaDB SkySQL to deploy a new service
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for service
+
+.PP
+\fB\-m\fP, \fB\-\-maxscale\-config\fP=""
+	Configurations for maxscale
+
+.PP
+\fB\-\-maxscale\-proxy\fP="false"
+	Whether to set up a proxy for maxscale
+
+.PP
+\fB\-\-monitor\fP="false"
+	Whether to deploy a monitoring cluster alongside the service
+
+.PP
+\fB\-n\fP, \fB\-\-name\fP=""
+	Name used to identify the service
+
+.PP
+\fB\-p\fP, \fB\-\-provider\fP=""
+	Cloud provider to host the service
+
+.PP
+\fB\-r\fP, \fB\-\-region\fP=""
+	Geographic region to deploy the service
+
+.PP
+\fB\-v\fP, \fB\-\-release\-version\fP=""
+	Release version to deploy
+
+.PP
+\fB\-\-repl\-region\fP=""
+	Replica region for the service
+
+.PP
+\fB\-\-replicas\fP="0"
+	Number of replicas to deploy
+
+.PP
+\fB\-s\fP, \fB\-\-size\fP="Sky\-2x4"
+	Size of the nodes running the service
+
+.PP
+\fB\-\-ssl\-tls\fP="Enabled"
+	Specify whether to use SSL/TLS encryption
+
+.PP
+\fB\-g\fP, \fB\-\-storage\fP="100"
+	Size of the persistent storage disk
+
+.PP
+\fB\-\-tier\fP=""
+	Tier in which to provision service
+
+.PP
+\fB\-t\fP, \fB\-\-topology\fP="Standalone"
+	Service topology to select
+
+.PP
+\fB\-\-volume\-iops\fP=""
+	Amount of IOPS for the volume (e.g. 100). Required for Amazon AWS
+
+.PP
+\fB\-\-volume\-type\fP=""
+	Type of volume to use (e.g. io1, gp3). Required for Amazon AWS
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-create(3)\fP

--- a/docs/man/skysqlcli-create.3
+++ b/docs/man/skysqlcli-create.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-create \- Create a resource in MariaDB SkySQL
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli create [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Commands which deploy resources into MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for create
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli(3)\fP, \fBskysqlcli\-create\-allowed\-address(3)\fP, \fBskysqlcli\-create\-configuration(3)\fP, \fBskysqlcli\-create\-service(3)\fP

--- a/docs/man/skysqlcli-delete-allowed-address.3
+++ b/docs/man/skysqlcli-delete-allowed-address.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-delete\-allowed\-address \- Delete an allowed address from a service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli delete allowed\-address [SERVICE] [ALLOWED\-ADDRESS] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Deletes an allowed address for user on service in MariaDB SkySQL.
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for allowed\-address
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-delete(3)\fP

--- a/docs/man/skysqlcli-delete-configuration.3
+++ b/docs/man/skysqlcli-delete-configuration.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-delete\-configuration \- Delete a service configuration
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli delete configuration [CONFIGURATION] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Deletes a service configuration for user in MariaDB SkySQL.
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for configuration
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-delete(3)\fP

--- a/docs/man/skysqlcli-delete-service.3
+++ b/docs/man/skysqlcli-delete-service.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-delete\-service \- Delete an existing service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli delete service [SERVICE] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Submits request to MariaDB SkySQL to delete an existing service. Specify a service using the service id (e.g. db00000000)
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for service
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-delete(3)\fP

--- a/docs/man/skysqlcli-delete.3
+++ b/docs/man/skysqlcli-delete.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-delete \- Delete a resource in MariaDB SkySQL
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli delete [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Commands which delete existing resources in MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for delete
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli(3)\fP, \fBskysqlcli\-delete\-allowed\-address(3)\fP, \fBskysqlcli\-delete\-configuration(3)\fP, \fBskysqlcli\-delete\-service(3)\fP

--- a/docs/man/skysqlcli-get-allowlist.3
+++ b/docs/man/skysqlcli-get-allowlist.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-allowlist \- Retrieve list of allowed IPs for a service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get allowlist [SERVICE] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Queries for list of allowed IP addresses for a specific service
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for allowlist
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-configurations.3
+++ b/docs/man/skysqlcli-get-configurations.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-configurations \- Retrieve stored service configurations
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get configurations [CONFIGURATION] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Retrieves one or more custom service configurations owned by the user
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for configurations
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-products.3
+++ b/docs/man/skysqlcli-get-products.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-products \- Retrieve MariaDB SkySQL product information
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get products [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Queries information for product offerings from MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for products
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-providers.3
+++ b/docs/man/skysqlcli-get-providers.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-providers \- Retrieve list of cloud providers
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get providers [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Queries a list of cloud providers supported by MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for providers
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-quotas.3
+++ b/docs/man/skysqlcli-get-quotas.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-quotas \- Retrieve quota information
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get quotas [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Queries for quota limits, and progress towards those quotas.
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for quotas
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-regions.3
+++ b/docs/man/skysqlcli-get-regions.3
@@ -1,0 +1,53 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-regions \- Retrieve list of provider regions
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get regions [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Retrieves list of provider regions available for use with MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for regions
+
+.PP
+\fB\-\-provider\fP=""
+	MariaDB SkySQL provider to query for storage sizes
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-services.3
+++ b/docs/man/skysqlcli-get-services.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-services \- Retrieve service information
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get services [SERVICE] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Queries for information about deployed service resources in SkySQL. Specify a service using the service id (e.g. db00000000)
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for services
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-sizes.3
+++ b/docs/man/skysqlcli-get-sizes.3
@@ -1,0 +1,61 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-sizes \- Retrieve list of machine sizes
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get sizes [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Retrieves list of machine sizes available for use with MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for sizes
+
+.PP
+\fB\-\-product\fP=""
+	MariaDB SkySQL product to query for machine sizes
+
+.PP
+\fB\-\-provider\fP=""
+	MariaDB SkySQL provider to query for machine sizes
+
+.PP
+\fB\-\-tier\fP=""
+	MariaDB SkySQL tier to query for machine sizes
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-status.3
+++ b/docs/man/skysqlcli-get-status.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-status \- Get current status for a service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get status [SERVICE] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Get the current status of a service in MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for status
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-tiers.3
+++ b/docs/man/skysqlcli-get-tiers.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-tiers \- Retrieve list of MariaDB SkySQL account tiers
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get tiers [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Retrieves list of account tiers available for use with MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for tiers
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-topologies.3
+++ b/docs/man/skysqlcli-get-topologies.3
@@ -1,0 +1,53 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-topologies \- Retrieve list of MariaDB SkySQL service topologies
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get topologies [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Retrieves list of service topologies available for use with MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for topologies
+
+.PP
+\fB\-p\fP, \fB\-\-product\fP=""
+	MariaDB SkySQL product used to filter list of topologies
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get-versions.3
+++ b/docs/man/skysqlcli-get-versions.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get\-versions \- Retrieve list of MariaDB SkySQL service versions
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get versions [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Retrieves list of service versions available for use with MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for versions
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-get(3)\fP

--- a/docs/man/skysqlcli-get.3
+++ b/docs/man/skysqlcli-get.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-get \- Query MariaDB SkySQL for resource information
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli get [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Commands which retrieve data about resources deployed into MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for get
+
+.PP
+\fB\-l\fP, \fB\-\-limit\fP=10
+	Number of records to return
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli(3)\fP, \fBskysqlcli\-get\-allowlist(3)\fP, \fBskysqlcli\-get\-configurations(3)\fP, \fBskysqlcli\-get\-products(3)\fP, \fBskysqlcli\-get\-providers(3)\fP, \fBskysqlcli\-get\-quotas(3)\fP, \fBskysqlcli\-get\-regions(3)\fP, \fBskysqlcli\-get\-services(3)\fP, \fBskysqlcli\-get\-sizes(3)\fP, \fBskysqlcli\-get\-status(3)\fP, \fBskysqlcli\-get\-tiers(3)\fP, \fBskysqlcli\-get\-topologies(3)\fP, \fBskysqlcli\-get\-versions(3)\fP

--- a/docs/man/skysqlcli-update-configuration.3
+++ b/docs/man/skysqlcli-update-configuration.3
@@ -1,0 +1,53 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-update\-configuration \- Update a configuration
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli update configuration [CONFIGURATION] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Updates a configuration for user in MariaDB SkySQL.
+
+
+.SH OPTIONS
+.PP
+\fB\-j\fP, \fB\-\-config\-json\fP=""
+	JSON object containing configuration
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for configuration
+
+.PP
+\fB\-n\fP, \fB\-\-name\fP=""
+	Name used to identify the configuration
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-update(3)\fP

--- a/docs/man/skysqlcli-update-service.3
+++ b/docs/man/skysqlcli-update-service.3
@@ -1,0 +1,49 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-update\-service \- Update an existing service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli update service [SERVICE] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Submits request to MariaDB SkySQL to update an existing service. Specify a service using the service id (e.g. db00000000)
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for service
+
+.PP
+\fB\-n\fP, \fB\-\-name\fP=""
+	Name used to identify the service
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-update(3)\fP

--- a/docs/man/skysqlcli-update-status.3
+++ b/docs/man/skysqlcli-update-status.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-update\-status \- Update status for service
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli update status [SERVICE] [Start|Stop] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Updates status for service belonging user in MariaDB SkySQL.
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for status
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-update(3)\fP

--- a/docs/man/skysqlcli-update.3
+++ b/docs/man/skysqlcli-update.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-update \- Update a resource in MariaDB SkySQL
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli update [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Commands which update existing resources into MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for update
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli(3)\fP, \fBskysqlcli\-update\-configuration(3)\fP, \fBskysqlcli\-update\-service(3)\fP, \fBskysqlcli\-update\-status(3)\fP

--- a/docs/man/skysqlcli-version.3
+++ b/docs/man/skysqlcli-version.3
@@ -1,0 +1,45 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli\-version \- Print the version number
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli version [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Print the version number of the cli
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for version
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli(3)\fP

--- a/docs/man/skysqlcli.3
+++ b/docs/man/skysqlcli.3
@@ -1,0 +1,43 @@
+.nh
+.TH "SkySQL CLI Client" "3" "Nov 2021" "MariaDB Corporation" ""
+
+.SH NAME
+.PP
+skysqlcli \- CLI client to interact with the SkySQL API
+
+
+.SH SYNOPSIS
+.PP
+\fBskysqlcli [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+A command line tool for managing resources deployed into MariaDB SkySQL
+
+
+.SH OPTIONS
+.PP
+\fB\-\-api\-key\fP=""
+	Long\-lived JWT issued from MariaDB ID
+
+.PP
+\fB\-c\fP, \fB\-\-config\fP=""
+	config file (default $HOME/.skysqlcli.yaml)
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for skysqlcli
+
+.PP
+\fB\-\-host\fP="https://api.dev.gcp.mariadb.net"
+	URL for the SkySQL API
+
+.PP
+\fB\-\-mdbid\fP="https://id\-dev.mariadb.com"
+	URL for MariaDB ID
+
+
+.SH SEE ALSO
+.PP
+\fBskysqlcli\-create(3)\fP, \fBskysqlcli\-delete(3)\fP, \fBskysqlcli\-get(3)\fP, \fBskysqlcli\-update(3)\fP, \fBskysqlcli\-version(3)\fP

--- a/docs/md/skysqlcli.md
+++ b/docs/md/skysqlcli.md
@@ -1,0 +1,26 @@
+## skysqlcli
+
+CLI client to interact with the SkySQL API
+
+### Synopsis
+
+A command line tool for managing resources deployed into MariaDB SkySQL
+
+### Options
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+  -h, --help             help for skysqlcli
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli create](skysqlcli_create.md)	 - Create a resource in MariaDB SkySQL
+* [skysqlcli delete](skysqlcli_delete.md)	 - Delete a resource in MariaDB SkySQL
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+* [skysqlcli update](skysqlcli_update.md)	 - Update a resource in MariaDB SkySQL
+* [skysqlcli version](skysqlcli_version.md)	 - Print the version number
+

--- a/docs/md/skysqlcli_create.md
+++ b/docs/md/skysqlcli_create.md
@@ -1,0 +1,30 @@
+## skysqlcli create
+
+Create a resource in MariaDB SkySQL
+
+### Synopsis
+
+Commands which deploy resources into MariaDB SkySQL
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli](skysqlcli.md)	 - CLI client to interact with the SkySQL API
+* [skysqlcli create allowed-address](skysqlcli_create_allowed-address.md)	 - Add a new allowed address to a service
+* [skysqlcli create configuration](skysqlcli_create_configuration.md)	 - Create a new configuration
+* [skysqlcli create service](skysqlcli_create_service.md)	 - Create a new service
+

--- a/docs/md/skysqlcli_create_allowed-address.md
+++ b/docs/md/skysqlcli_create_allowed-address.md
@@ -1,0 +1,32 @@
+## skysqlcli create allowed-address
+
+Add a new allowed address to a service
+
+### Synopsis
+
+Adds a new allowed address for service in MariaDB SkySQL.
+
+```
+skysqlcli create allowed-address [SERVICE] [IP-ADDRESS] [flags]
+```
+
+### Options
+
+```
+      --comment string   Additional comment to help identify address
+  -h, --help             help for allowed-address
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli create](skysqlcli_create.md)	 - Create a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_create_configuration.md
+++ b/docs/md/skysqlcli_create_configuration.md
@@ -1,0 +1,34 @@
+## skysqlcli create configuration
+
+Create a new configuration
+
+### Synopsis
+
+Creates a new configuration for user in MariaDB SkySQL.
+
+```
+skysqlcli create configuration [flags]
+```
+
+### Options
+
+```
+  -j, --config-json string   JSON object containing configuration (default "\n\t\t{\n\t\t\t\"variables\": {\n\t\t\t\t\"interactive_timeout\": {\n\t\t\t\t\t\"type\": \"number\",\n\t\t\t\t\t\"value\": \"300\",\n\t\t\t\t\t\"requires_restart\": true,\n\t\t\t\t\t\"regex\": \"\"\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t")
+  -h, --help                 help for configuration
+  -n, --name string          Name used to identify the configuration (default "HA")
+  -t, --topology string      Configuration topology to select (default "Primary/Replica")
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli create](skysqlcli_create.md)	 - Create a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_create_service.md
+++ b/docs/md/skysqlcli_create_service.md
@@ -1,0 +1,47 @@
+## skysqlcli create service
+
+Create a new service
+
+### Synopsis
+
+Submits request to MariaDB SkySQL to deploy a new service
+
+```
+skysqlcli create service [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for service
+  -m, --maxscale-config string   Configurations for maxscale
+      --maxscale-proxy string    Whether to set up a proxy for maxscale (default "false")
+      --monitor string           Whether to deploy a monitoring cluster alongside the service (default "false")
+  -n, --name string              Name used to identify the service
+  -p, --provider string          Cloud provider to host the service
+  -r, --region string            Geographic region to deploy the service
+  -v, --release-version string   Release version to deploy
+      --repl-region string       Replica region for the service
+      --replicas string          Number of replicas to deploy (default "0")
+  -s, --size string              Size of the nodes running the service (default "Sky-2x4")
+      --ssl-tls string           Specify whether to use SSL/TLS encryption (default "Enabled")
+  -g, --storage string           Size of the persistent storage disk (default "100")
+      --tier string              Tier in which to provision service
+  -t, --topology string          Service topology to select (default "Standalone")
+      --volume-iops string       Amount of IOPS for the volume (e.g. 100). Required for Amazon AWS
+      --volume-type string       Type of volume to use (e.g. io1, gp3). Required for Amazon AWS
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli create](skysqlcli_create.md)	 - Create a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_delete.md
+++ b/docs/md/skysqlcli_delete.md
@@ -1,0 +1,30 @@
+## skysqlcli delete
+
+Delete a resource in MariaDB SkySQL
+
+### Synopsis
+
+Commands which delete existing resources in MariaDB SkySQL
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli](skysqlcli.md)	 - CLI client to interact with the SkySQL API
+* [skysqlcli delete allowed-address](skysqlcli_delete_allowed-address.md)	 - Delete an allowed address from a service
+* [skysqlcli delete configuration](skysqlcli_delete_configuration.md)	 - Delete a service configuration
+* [skysqlcli delete service](skysqlcli_delete_service.md)	 - Delete an existing service
+

--- a/docs/md/skysqlcli_delete_allowed-address.md
+++ b/docs/md/skysqlcli_delete_allowed-address.md
@@ -1,0 +1,31 @@
+## skysqlcli delete allowed-address
+
+Delete an allowed address from a service
+
+### Synopsis
+
+Deletes an allowed address for user on service in MariaDB SkySQL.
+
+```
+skysqlcli delete allowed-address [SERVICE] [ALLOWED-ADDRESS] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for allowed-address
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli delete](skysqlcli_delete.md)	 - Delete a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_delete_configuration.md
+++ b/docs/md/skysqlcli_delete_configuration.md
@@ -1,0 +1,31 @@
+## skysqlcli delete configuration
+
+Delete a service configuration
+
+### Synopsis
+
+Deletes a service configuration for user in MariaDB SkySQL.
+
+```
+skysqlcli delete configuration [CONFIGURATION] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for configuration
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli delete](skysqlcli_delete.md)	 - Delete a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_delete_service.md
+++ b/docs/md/skysqlcli_delete_service.md
@@ -1,0 +1,31 @@
+## skysqlcli delete service
+
+Delete an existing service
+
+### Synopsis
+
+Submits request to MariaDB SkySQL to delete an existing service. Specify a service using the service id (e.g. db00000000)
+
+```
+skysqlcli delete service [SERVICE] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for service
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli delete](skysqlcli_delete.md)	 - Delete a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_get.md
+++ b/docs/md/skysqlcli_get.md
@@ -1,0 +1,40 @@
+## skysqlcli get
+
+Query MariaDB SkySQL for resource information
+
+### Synopsis
+
+Commands which retrieve data about resources deployed into MariaDB SkySQL
+
+### Options
+
+```
+  -h, --help        help for get
+  -l, --limit int   Number of records to return (default 10)
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli](skysqlcli.md)	 - CLI client to interact with the SkySQL API
+* [skysqlcli get allowlist](skysqlcli_get_allowlist.md)	 - Retrieve list of allowed IPs for a service
+* [skysqlcli get configurations](skysqlcli_get_configurations.md)	 - Retrieve stored service configurations
+* [skysqlcli get products](skysqlcli_get_products.md)	 - Retrieve MariaDB SkySQL product information
+* [skysqlcli get providers](skysqlcli_get_providers.md)	 - Retrieve list of cloud providers
+* [skysqlcli get quotas](skysqlcli_get_quotas.md)	 - Retrieve quota information
+* [skysqlcli get regions](skysqlcli_get_regions.md)	 - Retrieve list of provider regions
+* [skysqlcli get services](skysqlcli_get_services.md)	 - Retrieve service information
+* [skysqlcli get sizes](skysqlcli_get_sizes.md)	 - Retrieve list of machine sizes
+* [skysqlcli get status](skysqlcli_get_status.md)	 - Get current status for a service
+* [skysqlcli get tiers](skysqlcli_get_tiers.md)	 - Retrieve list of MariaDB SkySQL account tiers
+* [skysqlcli get topologies](skysqlcli_get_topologies.md)	 - Retrieve list of MariaDB SkySQL service topologies
+* [skysqlcli get versions](skysqlcli_get_versions.md)	 - Retrieve list of MariaDB SkySQL service versions
+

--- a/docs/md/skysqlcli_get_allowlist.md
+++ b/docs/md/skysqlcli_get_allowlist.md
@@ -1,0 +1,32 @@
+## skysqlcli get allowlist
+
+Retrieve list of allowed IPs for a service
+
+### Synopsis
+
+Queries for list of allowed IP addresses for a specific service
+
+```
+skysqlcli get allowlist [SERVICE] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for allowlist
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_configurations.md
+++ b/docs/md/skysqlcli_get_configurations.md
@@ -1,0 +1,32 @@
+## skysqlcli get configurations
+
+Retrieve stored service configurations
+
+### Synopsis
+
+Retrieves one or more custom service configurations owned by the user
+
+```
+skysqlcli get configurations [CONFIGURATION] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for configurations
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_products.md
+++ b/docs/md/skysqlcli_get_products.md
@@ -1,0 +1,32 @@
+## skysqlcli get products
+
+Retrieve MariaDB SkySQL product information
+
+### Synopsis
+
+Queries information for product offerings from MariaDB SkySQL
+
+```
+skysqlcli get products [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for products
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_providers.md
+++ b/docs/md/skysqlcli_get_providers.md
@@ -1,0 +1,32 @@
+## skysqlcli get providers
+
+Retrieve list of cloud providers
+
+### Synopsis
+
+Queries a list of cloud providers supported by MariaDB SkySQL
+
+```
+skysqlcli get providers [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for providers
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_quotas.md
+++ b/docs/md/skysqlcli_get_quotas.md
@@ -1,0 +1,32 @@
+## skysqlcli get quotas
+
+Retrieve quota information
+
+### Synopsis
+
+Queries for quota limits, and progress towards those quotas.
+
+```
+skysqlcli get quotas [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for quotas
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_regions.md
+++ b/docs/md/skysqlcli_get_regions.md
@@ -1,0 +1,33 @@
+## skysqlcli get regions
+
+Retrieve list of provider regions
+
+### Synopsis
+
+Retrieves list of provider regions available for use with MariaDB SkySQL
+
+```
+skysqlcli get regions [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for regions
+      --provider string   MariaDB SkySQL provider to query for storage sizes
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_services.md
+++ b/docs/md/skysqlcli_get_services.md
@@ -1,0 +1,32 @@
+## skysqlcli get services
+
+Retrieve service information
+
+### Synopsis
+
+Queries for information about deployed service resources in SkySQL. Specify a service using the service id (e.g. db00000000)
+
+```
+skysqlcli get services [SERVICE] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for services
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_sizes.md
+++ b/docs/md/skysqlcli_get_sizes.md
@@ -1,0 +1,35 @@
+## skysqlcli get sizes
+
+Retrieve list of machine sizes
+
+### Synopsis
+
+Retrieves list of machine sizes available for use with MariaDB SkySQL
+
+```
+skysqlcli get sizes [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for sizes
+      --product string    MariaDB SkySQL product to query for machine sizes
+      --provider string   MariaDB SkySQL provider to query for machine sizes
+      --tier string       MariaDB SkySQL tier to query for machine sizes
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_status.md
+++ b/docs/md/skysqlcli_get_status.md
@@ -1,0 +1,32 @@
+## skysqlcli get status
+
+Get current status for a service
+
+### Synopsis
+
+Get the current status of a service in MariaDB SkySQL
+
+```
+skysqlcli get status [SERVICE] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_tiers.md
+++ b/docs/md/skysqlcli_get_tiers.md
@@ -1,0 +1,32 @@
+## skysqlcli get tiers
+
+Retrieve list of MariaDB SkySQL account tiers
+
+### Synopsis
+
+Retrieves list of account tiers available for use with MariaDB SkySQL
+
+```
+skysqlcli get tiers [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for tiers
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_topologies.md
+++ b/docs/md/skysqlcli_get_topologies.md
@@ -1,0 +1,33 @@
+## skysqlcli get topologies
+
+Retrieve list of MariaDB SkySQL service topologies
+
+### Synopsis
+
+Retrieves list of service topologies available for use with MariaDB SkySQL
+
+```
+skysqlcli get topologies [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for topologies
+  -p, --product string   MariaDB SkySQL product used to filter list of topologies
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_get_versions.md
+++ b/docs/md/skysqlcli_get_versions.md
@@ -1,0 +1,32 @@
+## skysqlcli get versions
+
+Retrieve list of MariaDB SkySQL service versions
+
+### Synopsis
+
+Retrieves list of service versions available for use with MariaDB SkySQL
+
+```
+skysqlcli get versions [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for versions
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli get](skysqlcli_get.md)	 - Query MariaDB SkySQL for resource information
+

--- a/docs/md/skysqlcli_update.md
+++ b/docs/md/skysqlcli_update.md
@@ -1,0 +1,30 @@
+## skysqlcli update
+
+Update a resource in MariaDB SkySQL
+
+### Synopsis
+
+Commands which update existing resources into MariaDB SkySQL
+
+### Options
+
+```
+  -h, --help   help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli](skysqlcli.md)	 - CLI client to interact with the SkySQL API
+* [skysqlcli update configuration](skysqlcli_update_configuration.md)	 - Update a configuration
+* [skysqlcli update service](skysqlcli_update_service.md)	 - Update an existing service
+* [skysqlcli update status](skysqlcli_update_status.md)	 - Update status for service
+

--- a/docs/md/skysqlcli_update_configuration.md
+++ b/docs/md/skysqlcli_update_configuration.md
@@ -1,0 +1,33 @@
+## skysqlcli update configuration
+
+Update a configuration
+
+### Synopsis
+
+Updates a configuration for user in MariaDB SkySQL.
+
+```
+skysqlcli update configuration [CONFIGURATION] [flags]
+```
+
+### Options
+
+```
+  -j, --config-json string   JSON object containing configuration
+  -h, --help                 help for configuration
+  -n, --name string          Name used to identify the configuration
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli update](skysqlcli_update.md)	 - Update a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_update_service.md
+++ b/docs/md/skysqlcli_update_service.md
@@ -1,0 +1,32 @@
+## skysqlcli update service
+
+Update an existing service
+
+### Synopsis
+
+Submits request to MariaDB SkySQL to update an existing service. Specify a service using the service id (e.g. db00000000)
+
+```
+skysqlcli update service [SERVICE] [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for service
+  -n, --name string   Name used to identify the service
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli update](skysqlcli_update.md)	 - Update a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_update_status.md
+++ b/docs/md/skysqlcli_update_status.md
@@ -1,0 +1,31 @@
+## skysqlcli update status
+
+Update status for service
+
+### Synopsis
+
+Updates status for service belonging user in MariaDB SkySQL.
+
+```
+skysqlcli update status [SERVICE] [Start|Stop] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli update](skysqlcli_update.md)	 - Update a resource in MariaDB SkySQL
+

--- a/docs/md/skysqlcli_version.md
+++ b/docs/md/skysqlcli_version.md
@@ -1,0 +1,31 @@
+## skysqlcli version
+
+Print the version number
+
+### Synopsis
+
+Print the version number of the cli
+
+```
+skysqlcli version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+```
+
+### SEE ALSO
+
+* [skysqlcli](skysqlcli.md)	 - CLI client to interact with the SkySQL API
+

--- a/docs/rst/skysqlcli.rst
+++ b/docs/rst/skysqlcli.rst
@@ -1,0 +1,33 @@
+.. _skysqlcli:
+
+skysqlcli
+---------
+
+CLI client to interact with the SkySQL API
+
+Synopsis
+~~~~~~~~
+
+
+A command line tool for managing resources deployed into MariaDB SkySQL
+
+Options
+~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+  -h, --help             help for skysqlcli
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli create <skysqlcli_create.rst>`_ 	 - Create a resource in MariaDB SkySQL
+* `skysqlcli delete <skysqlcli_delete.rst>`_ 	 - Delete a resource in MariaDB SkySQL
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+* `skysqlcli update <skysqlcli_update.rst>`_ 	 - Update a resource in MariaDB SkySQL
+* `skysqlcli version <skysqlcli_version.rst>`_ 	 - Print the version number
+

--- a/docs/rst/skysqlcli_create.rst
+++ b/docs/rst/skysqlcli_create.rst
@@ -1,0 +1,38 @@
+.. _skysqlcli_create:
+
+skysqlcli create
+----------------
+
+Create a resource in MariaDB SkySQL
+
+Synopsis
+~~~~~~~~
+
+
+Commands which deploy resources into MariaDB SkySQL
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for create
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli <skysqlcli.rst>`_ 	 - CLI client to interact with the SkySQL API
+* `skysqlcli create allowed-address <skysqlcli_create_allowed-address.rst>`_ 	 - Add a new allowed address to a service
+* `skysqlcli create configuration <skysqlcli_create_configuration.rst>`_ 	 - Create a new configuration
+* `skysqlcli create service <skysqlcli_create_service.rst>`_ 	 - Create a new service
+

--- a/docs/rst/skysqlcli_create_allowed-address.rst
+++ b/docs/rst/skysqlcli_create_allowed-address.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_create_allowed-address:
+
+skysqlcli create allowed-address
+--------------------------------
+
+Add a new allowed address to a service
+
+Synopsis
+~~~~~~~~
+
+
+Adds a new allowed address for service in MariaDB SkySQL.
+
+::
+
+  skysqlcli create allowed-address [SERVICE] [IP-ADDRESS] [flags]
+
+Options
+~~~~~~~
+
+::
+
+      --comment string   Additional comment to help identify address
+  -h, --help             help for allowed-address
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli create <skysqlcli_create.rst>`_ 	 - Create a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_create_configuration.rst
+++ b/docs/rst/skysqlcli_create_configuration.rst
@@ -1,0 +1,42 @@
+.. _skysqlcli_create_configuration:
+
+skysqlcli create configuration
+------------------------------
+
+Create a new configuration
+
+Synopsis
+~~~~~~~~
+
+
+Creates a new configuration for user in MariaDB SkySQL.
+
+::
+
+  skysqlcli create configuration [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -j, --config-json string   JSON object containing configuration (default "\n\t\t{\n\t\t\t\"variables\": {\n\t\t\t\t\"interactive_timeout\": {\n\t\t\t\t\t\"type\": \"number\",\n\t\t\t\t\t\"value\": \"300\",\n\t\t\t\t\t\"requires_restart\": true,\n\t\t\t\t\t\"regex\": \"\"\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t")
+  -h, --help                 help for configuration
+  -n, --name string          Name used to identify the configuration (default "HA")
+  -t, --topology string      Configuration topology to select (default "Primary/Replica")
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli create <skysqlcli_create.rst>`_ 	 - Create a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_create_service.rst
+++ b/docs/rst/skysqlcli_create_service.rst
@@ -1,0 +1,55 @@
+.. _skysqlcli_create_service:
+
+skysqlcli create service
+------------------------
+
+Create a new service
+
+Synopsis
+~~~~~~~~
+
+
+Submits request to MariaDB SkySQL to deploy a new service
+
+::
+
+  skysqlcli create service [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help                     help for service
+  -m, --maxscale-config string   Configurations for maxscale
+      --maxscale-proxy string    Whether to set up a proxy for maxscale (default "false")
+      --monitor string           Whether to deploy a monitoring cluster alongside the service (default "false")
+  -n, --name string              Name used to identify the service
+  -p, --provider string          Cloud provider to host the service
+  -r, --region string            Geographic region to deploy the service
+  -v, --release-version string   Release version to deploy
+      --repl-region string       Replica region for the service
+      --replicas string          Number of replicas to deploy (default "0")
+  -s, --size string              Size of the nodes running the service (default "Sky-2x4")
+      --ssl-tls string           Specify whether to use SSL/TLS encryption (default "Enabled")
+  -g, --storage string           Size of the persistent storage disk (default "100")
+      --tier string              Tier in which to provision service
+  -t, --topology string          Service topology to select (default "Standalone")
+      --volume-iops string       Amount of IOPS for the volume (e.g. 100). Required for Amazon AWS
+      --volume-type string       Type of volume to use (e.g. io1, gp3). Required for Amazon AWS
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli create <skysqlcli_create.rst>`_ 	 - Create a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_delete.rst
+++ b/docs/rst/skysqlcli_delete.rst
@@ -1,0 +1,38 @@
+.. _skysqlcli_delete:
+
+skysqlcli delete
+----------------
+
+Delete a resource in MariaDB SkySQL
+
+Synopsis
+~~~~~~~~
+
+
+Commands which delete existing resources in MariaDB SkySQL
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for delete
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli <skysqlcli.rst>`_ 	 - CLI client to interact with the SkySQL API
+* `skysqlcli delete allowed-address <skysqlcli_delete_allowed-address.rst>`_ 	 - Delete an allowed address from a service
+* `skysqlcli delete configuration <skysqlcli_delete_configuration.rst>`_ 	 - Delete a service configuration
+* `skysqlcli delete service <skysqlcli_delete_service.rst>`_ 	 - Delete an existing service
+

--- a/docs/rst/skysqlcli_delete_allowed-address.rst
+++ b/docs/rst/skysqlcli_delete_allowed-address.rst
@@ -1,0 +1,39 @@
+.. _skysqlcli_delete_allowed-address:
+
+skysqlcli delete allowed-address
+--------------------------------
+
+Delete an allowed address from a service
+
+Synopsis
+~~~~~~~~
+
+
+Deletes an allowed address for user on service in MariaDB SkySQL.
+
+::
+
+  skysqlcli delete allowed-address [SERVICE] [ALLOWED-ADDRESS] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for allowed-address
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli delete <skysqlcli_delete.rst>`_ 	 - Delete a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_delete_configuration.rst
+++ b/docs/rst/skysqlcli_delete_configuration.rst
@@ -1,0 +1,39 @@
+.. _skysqlcli_delete_configuration:
+
+skysqlcli delete configuration
+------------------------------
+
+Delete a service configuration
+
+Synopsis
+~~~~~~~~
+
+
+Deletes a service configuration for user in MariaDB SkySQL.
+
+::
+
+  skysqlcli delete configuration [CONFIGURATION] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for configuration
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli delete <skysqlcli_delete.rst>`_ 	 - Delete a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_delete_service.rst
+++ b/docs/rst/skysqlcli_delete_service.rst
@@ -1,0 +1,39 @@
+.. _skysqlcli_delete_service:
+
+skysqlcli delete service
+------------------------
+
+Delete an existing service
+
+Synopsis
+~~~~~~~~
+
+
+Submits request to MariaDB SkySQL to delete an existing service. Specify a service using the service id (e.g. db00000000)
+
+::
+
+  skysqlcli delete service [SERVICE] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for service
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli delete <skysqlcli_delete.rst>`_ 	 - Delete a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_get.rst
+++ b/docs/rst/skysqlcli_get.rst
@@ -1,0 +1,48 @@
+.. _skysqlcli_get:
+
+skysqlcli get
+-------------
+
+Query MariaDB SkySQL for resource information
+
+Synopsis
+~~~~~~~~
+
+
+Commands which retrieve data about resources deployed into MariaDB SkySQL
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help        help for get
+  -l, --limit int   Number of records to return (default 10)
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli <skysqlcli.rst>`_ 	 - CLI client to interact with the SkySQL API
+* `skysqlcli get allowlist <skysqlcli_get_allowlist.rst>`_ 	 - Retrieve list of allowed IPs for a service
+* `skysqlcli get configurations <skysqlcli_get_configurations.rst>`_ 	 - Retrieve stored service configurations
+* `skysqlcli get products <skysqlcli_get_products.rst>`_ 	 - Retrieve MariaDB SkySQL product information
+* `skysqlcli get providers <skysqlcli_get_providers.rst>`_ 	 - Retrieve list of cloud providers
+* `skysqlcli get quotas <skysqlcli_get_quotas.rst>`_ 	 - Retrieve quota information
+* `skysqlcli get regions <skysqlcli_get_regions.rst>`_ 	 - Retrieve list of provider regions
+* `skysqlcli get services <skysqlcli_get_services.rst>`_ 	 - Retrieve service information
+* `skysqlcli get sizes <skysqlcli_get_sizes.rst>`_ 	 - Retrieve list of machine sizes
+* `skysqlcli get status <skysqlcli_get_status.rst>`_ 	 - Get current status for a service
+* `skysqlcli get tiers <skysqlcli_get_tiers.rst>`_ 	 - Retrieve list of MariaDB SkySQL account tiers
+* `skysqlcli get topologies <skysqlcli_get_topologies.rst>`_ 	 - Retrieve list of MariaDB SkySQL service topologies
+* `skysqlcli get versions <skysqlcli_get_versions.rst>`_ 	 - Retrieve list of MariaDB SkySQL service versions
+

--- a/docs/rst/skysqlcli_get_allowlist.rst
+++ b/docs/rst/skysqlcli_get_allowlist.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_allowlist:
+
+skysqlcli get allowlist
+-----------------------
+
+Retrieve list of allowed IPs for a service
+
+Synopsis
+~~~~~~~~
+
+
+Queries for list of allowed IP addresses for a specific service
+
+::
+
+  skysqlcli get allowlist [SERVICE] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for allowlist
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_configurations.rst
+++ b/docs/rst/skysqlcli_get_configurations.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_configurations:
+
+skysqlcli get configurations
+----------------------------
+
+Retrieve stored service configurations
+
+Synopsis
+~~~~~~~~
+
+
+Retrieves one or more custom service configurations owned by the user
+
+::
+
+  skysqlcli get configurations [CONFIGURATION] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for configurations
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_products.rst
+++ b/docs/rst/skysqlcli_get_products.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_products:
+
+skysqlcli get products
+----------------------
+
+Retrieve MariaDB SkySQL product information
+
+Synopsis
+~~~~~~~~
+
+
+Queries information for product offerings from MariaDB SkySQL
+
+::
+
+  skysqlcli get products [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for products
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_providers.rst
+++ b/docs/rst/skysqlcli_get_providers.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_providers:
+
+skysqlcli get providers
+-----------------------
+
+Retrieve list of cloud providers
+
+Synopsis
+~~~~~~~~
+
+
+Queries a list of cloud providers supported by MariaDB SkySQL
+
+::
+
+  skysqlcli get providers [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for providers
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_quotas.rst
+++ b/docs/rst/skysqlcli_get_quotas.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_quotas:
+
+skysqlcli get quotas
+--------------------
+
+Retrieve quota information
+
+Synopsis
+~~~~~~~~
+
+
+Queries for quota limits, and progress towards those quotas.
+
+::
+
+  skysqlcli get quotas [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for quotas
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_regions.rst
+++ b/docs/rst/skysqlcli_get_regions.rst
@@ -1,0 +1,41 @@
+.. _skysqlcli_get_regions:
+
+skysqlcli get regions
+---------------------
+
+Retrieve list of provider regions
+
+Synopsis
+~~~~~~~~
+
+
+Retrieves list of provider regions available for use with MariaDB SkySQL
+
+::
+
+  skysqlcli get regions [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help              help for regions
+      --provider string   MariaDB SkySQL provider to query for storage sizes
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_services.rst
+++ b/docs/rst/skysqlcli_get_services.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_services:
+
+skysqlcli get services
+----------------------
+
+Retrieve service information
+
+Synopsis
+~~~~~~~~
+
+
+Queries for information about deployed service resources in SkySQL. Specify a service using the service id (e.g. db00000000)
+
+::
+
+  skysqlcli get services [SERVICE] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for services
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_sizes.rst
+++ b/docs/rst/skysqlcli_get_sizes.rst
@@ -1,0 +1,43 @@
+.. _skysqlcli_get_sizes:
+
+skysqlcli get sizes
+-------------------
+
+Retrieve list of machine sizes
+
+Synopsis
+~~~~~~~~
+
+
+Retrieves list of machine sizes available for use with MariaDB SkySQL
+
+::
+
+  skysqlcli get sizes [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help              help for sizes
+      --product string    MariaDB SkySQL product to query for machine sizes
+      --provider string   MariaDB SkySQL provider to query for machine sizes
+      --tier string       MariaDB SkySQL tier to query for machine sizes
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_status.rst
+++ b/docs/rst/skysqlcli_get_status.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_status:
+
+skysqlcli get status
+--------------------
+
+Get current status for a service
+
+Synopsis
+~~~~~~~~
+
+
+Get the current status of a service in MariaDB SkySQL
+
+::
+
+  skysqlcli get status [SERVICE] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for status
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_tiers.rst
+++ b/docs/rst/skysqlcli_get_tiers.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_tiers:
+
+skysqlcli get tiers
+-------------------
+
+Retrieve list of MariaDB SkySQL account tiers
+
+Synopsis
+~~~~~~~~
+
+
+Retrieves list of account tiers available for use with MariaDB SkySQL
+
+::
+
+  skysqlcli get tiers [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for tiers
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_topologies.rst
+++ b/docs/rst/skysqlcli_get_topologies.rst
@@ -1,0 +1,41 @@
+.. _skysqlcli_get_topologies:
+
+skysqlcli get topologies
+------------------------
+
+Retrieve list of MariaDB SkySQL service topologies
+
+Synopsis
+~~~~~~~~
+
+
+Retrieves list of service topologies available for use with MariaDB SkySQL
+
+::
+
+  skysqlcli get topologies [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help             help for topologies
+  -p, --product string   MariaDB SkySQL product used to filter list of topologies
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_get_versions.rst
+++ b/docs/rst/skysqlcli_get_versions.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_get_versions:
+
+skysqlcli get versions
+----------------------
+
+Retrieve list of MariaDB SkySQL service versions
+
+Synopsis
+~~~~~~~~
+
+
+Retrieves list of service versions available for use with MariaDB SkySQL
+
+::
+
+  skysqlcli get versions [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for versions
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+  -l, --limit int        Number of records to return (default 10)
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli get <skysqlcli_get.rst>`_ 	 - Query MariaDB SkySQL for resource information
+

--- a/docs/rst/skysqlcli_update.rst
+++ b/docs/rst/skysqlcli_update.rst
@@ -1,0 +1,38 @@
+.. _skysqlcli_update:
+
+skysqlcli update
+----------------
+
+Update a resource in MariaDB SkySQL
+
+Synopsis
+~~~~~~~~
+
+
+Commands which update existing resources into MariaDB SkySQL
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for update
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli <skysqlcli.rst>`_ 	 - CLI client to interact with the SkySQL API
+* `skysqlcli update configuration <skysqlcli_update_configuration.rst>`_ 	 - Update a configuration
+* `skysqlcli update service <skysqlcli_update_service.rst>`_ 	 - Update an existing service
+* `skysqlcli update status <skysqlcli_update_status.rst>`_ 	 - Update status for service
+

--- a/docs/rst/skysqlcli_update_configuration.rst
+++ b/docs/rst/skysqlcli_update_configuration.rst
@@ -1,0 +1,41 @@
+.. _skysqlcli_update_configuration:
+
+skysqlcli update configuration
+------------------------------
+
+Update a configuration
+
+Synopsis
+~~~~~~~~
+
+
+Updates a configuration for user in MariaDB SkySQL.
+
+::
+
+  skysqlcli update configuration [CONFIGURATION] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -j, --config-json string   JSON object containing configuration
+  -h, --help                 help for configuration
+  -n, --name string          Name used to identify the configuration
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli update <skysqlcli_update.rst>`_ 	 - Update a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_update_service.rst
+++ b/docs/rst/skysqlcli_update_service.rst
@@ -1,0 +1,40 @@
+.. _skysqlcli_update_service:
+
+skysqlcli update service
+------------------------
+
+Update an existing service
+
+Synopsis
+~~~~~~~~
+
+
+Submits request to MariaDB SkySQL to update an existing service. Specify a service using the service id (e.g. db00000000)
+
+::
+
+  skysqlcli update service [SERVICE] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help          help for service
+  -n, --name string   Name used to identify the service
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli update <skysqlcli_update.rst>`_ 	 - Update a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_update_status.rst
+++ b/docs/rst/skysqlcli_update_status.rst
@@ -1,0 +1,39 @@
+.. _skysqlcli_update_status:
+
+skysqlcli update status
+-----------------------
+
+Update status for service
+
+Synopsis
+~~~~~~~~
+
+
+Updates status for service belonging user in MariaDB SkySQL.
+
+::
+
+  skysqlcli update status [SERVICE] [Start|Stop] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for status
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli update <skysqlcli_update.rst>`_ 	 - Update a resource in MariaDB SkySQL
+

--- a/docs/rst/skysqlcli_version.rst
+++ b/docs/rst/skysqlcli_version.rst
@@ -1,0 +1,39 @@
+.. _skysqlcli_version:
+
+skysqlcli version
+-----------------
+
+Print the version number
+
+Synopsis
+~~~~~~~~
+
+
+Print the version number of the cli
+
+::
+
+  skysqlcli version [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for version
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --api-key string   Long-lived JWT issued from MariaDB ID
+  -c, --config string    config file (default $HOME/.skysqlcli.yaml)
+      --host string      URL for the SkySQL API (default "https://api.dev.gcp.mariadb.net")
+      --mdbid string     URL for MariaDB ID (default "https://id-dev.mariadb.com")
+
+SEE ALSO
+~~~~~~~~
+
+* `skysqlcli <skysqlcli.rst>`_ 	 - CLI client to interact with the SkySQL API
+

--- a/docs/yaml/skysqlcli.yaml
+++ b/docs/yaml/skysqlcli.yaml
@@ -1,0 +1,26 @@
+name: skysqlcli
+synopsis: CLI client to interact with the SkySQL API
+description: |
+  A command line tool for managing resources deployed into MariaDB SkySQL
+options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for skysqlcli
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- create - Create a resource in MariaDB SkySQL
+- delete - Delete a resource in MariaDB SkySQL
+- get - Query MariaDB SkySQL for resource information
+- update - Update a resource in MariaDB SkySQL
+- version - Print the version number

--- a/docs/yaml/skysqlcli_create.yaml
+++ b/docs/yaml/skysqlcli_create.yaml
@@ -1,0 +1,25 @@
+name: skysqlcli create
+synopsis: Create a resource in MariaDB SkySQL
+description: Commands which deploy resources into MariaDB SkySQL
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for create
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli - CLI client to interact with the SkySQL API
+- allowed-address - Add a new allowed address to a service
+- configuration - Create a new configuration
+- service - Create a new service

--- a/docs/yaml/skysqlcli_create_allowed-address.yaml
+++ b/docs/yaml/skysqlcli_create_allowed-address.yaml
@@ -1,0 +1,25 @@
+name: skysqlcli create allowed-address
+synopsis: Add a new allowed address to a service
+description: Adds a new allowed address for service in MariaDB SkySQL.
+usage: skysqlcli create allowed-address [SERVICE] [IP-ADDRESS] [flags]
+options:
+- name: comment
+  usage: Additional comment to help identify address
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for allowed-address
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli create - Create a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_create_configuration.yaml
+++ b/docs/yaml/skysqlcli_create_configuration.yaml
@@ -1,0 +1,37 @@
+name: skysqlcli create configuration
+synopsis: Create a new configuration
+description: Creates a new configuration for user in MariaDB SkySQL.
+usage: skysqlcli create configuration [flags]
+options:
+- name: config-json
+  shorthand: j
+  default_value: "\n\t\t{\n\t\t\t\"variables\": {\n\t\t\t\t\"interactive_timeout\":
+    {\n\t\t\t\t\t\"type\": \"number\",\n\t\t\t\t\t\"value\": \"300\",\n\t\t\t\t\t\"requires_restart\":
+    true,\n\t\t\t\t\t\"regex\": \"\"\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t"
+  usage: JSON object containing configuration
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for configuration
+- name: name
+  shorthand: "n"
+  default_value: HA
+  usage: Name used to identify the configuration
+- name: topology
+  shorthand: t
+  default_value: Primary/Replica
+  usage: Configuration topology to select
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli create - Create a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_create_service.yaml
+++ b/docs/yaml/skysqlcli_create_service.yaml
@@ -1,0 +1,72 @@
+name: skysqlcli create service
+synopsis: Create a new service
+description: Submits request to MariaDB SkySQL to deploy a new service
+usage: skysqlcli create service [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for service
+- name: maxscale-config
+  shorthand: m
+  usage: Configurations for maxscale
+- name: maxscale-proxy
+  default_value: "false"
+  usage: Whether to set up a proxy for maxscale
+- name: monitor
+  default_value: "false"
+  usage: Whether to deploy a monitoring cluster alongside the service
+- name: name
+  shorthand: "n"
+  usage: Name used to identify the service
+- name: provider
+  shorthand: p
+  usage: Cloud provider to host the service
+- name: region
+  shorthand: r
+  usage: Geographic region to deploy the service
+- name: release-version
+  shorthand: v
+  usage: Release version to deploy
+- name: repl-region
+  usage: Replica region for the service
+- name: replicas
+  default_value: "0"
+  usage: Number of replicas to deploy
+- name: size
+  shorthand: s
+  default_value: Sky-2x4
+  usage: Size of the nodes running the service
+- name: ssl-tls
+  default_value: Enabled
+  usage: Specify whether to use SSL/TLS encryption
+- name: storage
+  shorthand: g
+  default_value: "100"
+  usage: Size of the persistent storage disk
+- name: tier
+  usage: Tier in which to provision service
+- name: topology
+  shorthand: t
+  default_value: Standalone
+  usage: Service topology to select
+- name: volume-iops
+  usage: |
+    Amount of IOPS for the volume (e.g. 100). Required for Amazon AWS
+- name: volume-type
+  usage: |
+    Type of volume to use (e.g. io1, gp3). Required for Amazon AWS
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli create - Create a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_delete.yaml
+++ b/docs/yaml/skysqlcli_delete.yaml
@@ -1,0 +1,25 @@
+name: skysqlcli delete
+synopsis: Delete a resource in MariaDB SkySQL
+description: Commands which delete existing resources in MariaDB SkySQL
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for delete
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli - CLI client to interact with the SkySQL API
+- allowed-address - Delete an allowed address from a service
+- configuration - Delete a service configuration
+- service - Delete an existing service

--- a/docs/yaml/skysqlcli_delete_allowed-address.yaml
+++ b/docs/yaml/skysqlcli_delete_allowed-address.yaml
@@ -1,0 +1,24 @@
+name: skysqlcli delete allowed-address
+synopsis: Delete an allowed address from a service
+description: |
+  Deletes an allowed address for user on service in MariaDB SkySQL.
+usage: skysqlcli delete allowed-address [SERVICE] [ALLOWED-ADDRESS] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for allowed-address
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli delete - Delete a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_delete_configuration.yaml
+++ b/docs/yaml/skysqlcli_delete_configuration.yaml
@@ -1,0 +1,23 @@
+name: skysqlcli delete configuration
+synopsis: Delete a service configuration
+description: Deletes a service configuration for user in MariaDB SkySQL.
+usage: skysqlcli delete configuration [CONFIGURATION] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for configuration
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli delete - Delete a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_delete_service.yaml
+++ b/docs/yaml/skysqlcli_delete_service.yaml
@@ -1,0 +1,24 @@
+name: skysqlcli delete service
+synopsis: Delete an existing service
+description: |
+  Submits request to MariaDB SkySQL to delete an existing service. Specify a service using the service id (e.g. db00000000)
+usage: skysqlcli delete service [SERVICE] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for service
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli delete - Delete a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_get.yaml
+++ b/docs/yaml/skysqlcli_get.yaml
@@ -1,0 +1,39 @@
+name: skysqlcli get
+synopsis: Query MariaDB SkySQL for resource information
+description: |
+  Commands which retrieve data about resources deployed into MariaDB SkySQL
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for get
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli - CLI client to interact with the SkySQL API
+- allowlist - Retrieve list of allowed IPs for a service
+- configurations - Retrieve stored service configurations
+- products - Retrieve MariaDB SkySQL product information
+- providers - Retrieve list of cloud providers
+- quotas - Retrieve quota information
+- regions - Retrieve list of provider regions
+- services - Retrieve service information
+- sizes - Retrieve list of machine sizes
+- status - Get current status for a service
+- tiers - Retrieve list of MariaDB SkySQL account tiers
+- topologies - Retrieve list of MariaDB SkySQL service topologies
+- versions - Retrieve list of MariaDB SkySQL service versions

--- a/docs/yaml/skysqlcli_get_allowlist.yaml
+++ b/docs/yaml/skysqlcli_get_allowlist.yaml
@@ -1,0 +1,28 @@
+name: skysqlcli get allowlist
+synopsis: Retrieve list of allowed IPs for a service
+description: |
+  Queries for list of allowed IP addresses for a specific service
+usage: skysqlcli get allowlist [SERVICE] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for allowlist
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_configurations.yaml
+++ b/docs/yaml/skysqlcli_get_configurations.yaml
@@ -1,0 +1,28 @@
+name: skysqlcli get configurations
+synopsis: Retrieve stored service configurations
+description: |
+  Retrieves one or more custom service configurations owned by the user
+usage: skysqlcli get configurations [CONFIGURATION] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for configurations
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_products.yaml
+++ b/docs/yaml/skysqlcli_get_products.yaml
@@ -1,0 +1,28 @@
+name: skysqlcli get products
+synopsis: Retrieve MariaDB SkySQL product information
+description: |
+  Queries information for product offerings from MariaDB SkySQL
+usage: skysqlcli get products [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for products
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_providers.yaml
+++ b/docs/yaml/skysqlcli_get_providers.yaml
@@ -1,0 +1,28 @@
+name: skysqlcli get providers
+synopsis: Retrieve list of cloud providers
+description: |
+  Queries a list of cloud providers supported by MariaDB SkySQL
+usage: skysqlcli get providers [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for providers
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_quotas.yaml
+++ b/docs/yaml/skysqlcli_get_quotas.yaml
@@ -1,0 +1,27 @@
+name: skysqlcli get quotas
+synopsis: Retrieve quota information
+description: Queries for quota limits, and progress towards those quotas.
+usage: skysqlcli get quotas [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for quotas
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_regions.yaml
+++ b/docs/yaml/skysqlcli_get_regions.yaml
@@ -1,0 +1,30 @@
+name: skysqlcli get regions
+synopsis: Retrieve list of provider regions
+description: |
+  Retrieves list of provider regions available for use with MariaDB SkySQL
+usage: skysqlcli get regions [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for regions
+- name: provider
+  usage: MariaDB SkySQL provider to query for storage sizes
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_services.yaml
+++ b/docs/yaml/skysqlcli_get_services.yaml
@@ -1,0 +1,28 @@
+name: skysqlcli get services
+synopsis: Retrieve service information
+description: |
+  Queries for information about deployed service resources in SkySQL. Specify a service using the service id (e.g. db00000000)
+usage: skysqlcli get services [SERVICE] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for services
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_sizes.yaml
+++ b/docs/yaml/skysqlcli_get_sizes.yaml
@@ -1,0 +1,34 @@
+name: skysqlcli get sizes
+synopsis: Retrieve list of machine sizes
+description: |
+  Retrieves list of machine sizes available for use with MariaDB SkySQL
+usage: skysqlcli get sizes [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for sizes
+- name: product
+  usage: MariaDB SkySQL product to query for machine sizes
+- name: provider
+  usage: MariaDB SkySQL provider to query for machine sizes
+- name: tier
+  usage: MariaDB SkySQL tier to query for machine sizes
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_status.yaml
+++ b/docs/yaml/skysqlcli_get_status.yaml
@@ -1,0 +1,27 @@
+name: skysqlcli get status
+synopsis: Get current status for a service
+description: Get the current status of a service in MariaDB SkySQL
+usage: skysqlcli get status [SERVICE] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for status
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_tiers.yaml
+++ b/docs/yaml/skysqlcli_get_tiers.yaml
@@ -1,0 +1,28 @@
+name: skysqlcli get tiers
+synopsis: Retrieve list of MariaDB SkySQL account tiers
+description: |
+  Retrieves list of account tiers available for use with MariaDB SkySQL
+usage: skysqlcli get tiers [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for tiers
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_topologies.yaml
+++ b/docs/yaml/skysqlcli_get_topologies.yaml
@@ -1,0 +1,31 @@
+name: skysqlcli get topologies
+synopsis: Retrieve list of MariaDB SkySQL service topologies
+description: |
+  Retrieves list of service topologies available for use with MariaDB SkySQL
+usage: skysqlcli get topologies [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for topologies
+- name: product
+  shorthand: p
+  usage: MariaDB SkySQL product used to filter list of topologies
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_get_versions.yaml
+++ b/docs/yaml/skysqlcli_get_versions.yaml
@@ -1,0 +1,28 @@
+name: skysqlcli get versions
+synopsis: Retrieve list of MariaDB SkySQL service versions
+description: |
+  Retrieves list of service versions available for use with MariaDB SkySQL
+usage: skysqlcli get versions [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for versions
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: limit
+  shorthand: l
+  default_value: "10"
+  usage: Number of records to return
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli get - Query MariaDB SkySQL for resource information

--- a/docs/yaml/skysqlcli_update.yaml
+++ b/docs/yaml/skysqlcli_update.yaml
@@ -1,0 +1,25 @@
+name: skysqlcli update
+synopsis: Update a resource in MariaDB SkySQL
+description: Commands which update existing resources into MariaDB SkySQL
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for update
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli - CLI client to interact with the SkySQL API
+- configuration - Update a configuration
+- service - Update an existing service
+- status - Update status for service

--- a/docs/yaml/skysqlcli_update_configuration.yaml
+++ b/docs/yaml/skysqlcli_update_configuration.yaml
@@ -1,0 +1,29 @@
+name: skysqlcli update configuration
+synopsis: Update a configuration
+description: Updates a configuration for user in MariaDB SkySQL.
+usage: skysqlcli update configuration [CONFIGURATION] [flags]
+options:
+- name: config-json
+  shorthand: j
+  usage: JSON object containing configuration
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for configuration
+- name: name
+  shorthand: "n"
+  usage: Name used to identify the configuration
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli update - Update a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_update_service.yaml
+++ b/docs/yaml/skysqlcli_update_service.yaml
@@ -1,0 +1,27 @@
+name: skysqlcli update service
+synopsis: Update an existing service
+description: |
+  Submits request to MariaDB SkySQL to update an existing service. Specify a service using the service id (e.g. db00000000)
+usage: skysqlcli update service [SERVICE] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for service
+- name: name
+  shorthand: "n"
+  usage: Name used to identify the service
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli update - Update a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_update_status.yaml
+++ b/docs/yaml/skysqlcli_update_status.yaml
@@ -1,0 +1,23 @@
+name: skysqlcli update status
+synopsis: Update status for service
+description: Updates status for service belonging user in MariaDB SkySQL.
+usage: skysqlcli update status [SERVICE] [Start|Stop] [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for status
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli update - Update a resource in MariaDB SkySQL

--- a/docs/yaml/skysqlcli_version.yaml
+++ b/docs/yaml/skysqlcli_version.yaml
@@ -1,0 +1,23 @@
+name: skysqlcli version
+synopsis: Print the version number
+description: Print the version number of the cli
+usage: skysqlcli version [flags]
+options:
+- name: help
+  shorthand: h
+  default_value: "false"
+  usage: help for version
+inherited_options:
+- name: api-key
+  usage: Long-lived JWT issued from MariaDB ID
+- name: config
+  shorthand: c
+  usage: config file (default $HOME/.skysqlcli.yaml)
+- name: host
+  default_value: https://api.dev.gcp.mariadb.net
+  usage: URL for the SkySQL API
+- name: mdbid
+  default_value: https://id-dev.mariadb.com
+  usage: URL for MariaDB ID
+see_also:
+- skysqlcli - CLI client to interact with the SkySQL API

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -17,6 +18,8 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -238,9 +239,11 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=


### PR DESCRIPTION
With the hope of helping out the docs team, this commit introduces a
new make target (`make docs`) which executes a script (`docs/main.go`)
that will walk the command tree for the skysqlcli and generate
documentation based on the `--help` for every command.

Since I imagine that different people will want that information in
different forms, I went ahead and generated it in each format that cobra
had implemented. That is...

* Markdown
* YAML
* ReSTructured text
* Linux manuals

This will hopefully make it a bit easier for someone walking up to the
cli for the first time to be able to browse around the docs before
committing to downloading the binaries and giving it a spin.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [x] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
