### PR TITLE
Install golang for release job in pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+env:
+  GOPRIVATE: github.com/mariadb-corporation
 jobs:
   version-info:
     name: Version info
@@ -33,8 +35,6 @@ jobs:
     name: Build artifacts
     runs-on: ${{ matrix.os }}
     needs: version-info
-    env:
-      GOPRIVATE: github.com/mariadb-corporation
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest]
@@ -94,6 +94,15 @@ jobs:
           fetch-depth: "0"
       - name: Install Auto
         run : npm i -g auto @auto-it/upload-assets @auto-it/git-tag @auto-it/pr-body-labels @auto-it/exec
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Configure git for private repos
+        run : |
+          git config --global url."https://${{ secrets.PRIVATE_REPO_TOKEN }}@github.com/mariadb-corporation".insteadOf "https://github.com/mariadb-corporation"
+      - name: Install Deps
+        run : make deps
       - name: linux binary
         id: linux-binary
         uses: actions/cache@v2


### PR DESCRIPTION
Since I'm using that script to generate the docs automatically, I need
to have golang installed and configured for our private repos for it to
be able to walk through the command. We _could_ make a binary for the
docs gen, but it's only ever used in the pipeline so I figure a go run
is fine.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [x] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
