### PR TITLE
Establish reasonable defaults for job timeouts in pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on: pull_request
 jobs:
   pr-check:
       name: Check pull request labels
+      timeout-minutes: 5
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   version-info:
     name: Version info
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.compute_tag.outputs.next_tag }}
@@ -33,6 +34,7 @@ jobs:
           version_type: ${{ env.VERSION_TYPE }}
   artifacts:
     name: Build artifacts
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     needs: version-info
     strategy:
@@ -82,6 +84,7 @@ jobs:
   release:
     name: Publish new release
     if: github.ref == 'refs/heads/main'
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [artifacts]
     outputs:


### PR DESCRIPTION
Turns out the default job timeout in GitHub Actions is 6 hours:
https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits

Not sure who thought that was a good idea, but it has resulted in a
couple of jobs this month that tried to push an image to the GiHub
Packages registry that failed and just sat there eating up minutes.

So, I'm locking down each job explictly with timeouts that are at least
2x their normal runtime.

DBAAS-8498

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [x] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
