### PR TITLE
Add `-n, --name` flag for querying services

### DIFF
--- a/cmd/get_services.go
+++ b/cmd/get_services.go
@@ -17,6 +17,9 @@ var (
 		Short:   "Retrieve service information",
 		Long:    "Queries for information about deployed service resources in SkySQL. " + HINT_SVC_ID,
 		Args:    cobra.MaximumNArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag(NAME, cmd.PersistentFlags().Lookup(NAME))
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			var res *http.Response
 			var err error
@@ -25,8 +28,10 @@ var (
 				res, err = client.ReadService(cmd.Context(), svcid)
 			} else {
 				limit := viper.GetInt("limit")
+				name := viper.GetString("name")
 				res, err = client.ListServices(cmd.Context(), &skysql.ListServicesParams{
 					Limit: &limit,
+					Name:  &name,
 				})
 			}
 			checkAndPrint(res, err, SERVICES)
@@ -36,4 +41,6 @@ var (
 
 func init() {
 	getCmd.AddCommand(getServiceCmd)
+
+	getServiceCmd.PersistentFlags().StringP(NAME, "n", "", "Search string to match any services containing the name")
 }

--- a/cmd/get_topologies.go
+++ b/cmd/get_topologies.go
@@ -21,7 +21,7 @@ var (
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			limit := viper.GetInt(LIMIT)
-			product := viper.GetString(PRODUCT)
+			product := skysql.ReadTopologiesParamsProduct(viper.GetString(PRODUCT))
 
 			var res *http.Response
 			var err error

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/deepmap/oapi-codegen v1.8.2
-	github.com/mariadb-corporation/skysql-api-go v0.0.16
+	github.com/mariadb-corporation/skysql-api-go v0.0.18
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mariadb-corporation/skysql-api-go v0.0.16 h1:mTEfHYEJniNh2ixoRH38u0OMxSBjcmld4Wu0I5bH9EY=
-github.com/mariadb-corporation/skysql-api-go v0.0.16/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
+github.com/mariadb-corporation/skysql-api-go v0.0.18 h1:D1CmJjqXAcVl1lj0CYuV6dJWNWMpudutCirYo6CpEKY=
+github.com/mariadb-corporation/skysql-api-go v0.0.18/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
Now you can query services by name instead of only by ID. The name is
used as a search term (in a `CONTAINS` query), so you don't even have to
put the whole name there and any service that contains what you provide
will be returned.

That way if you have several services that all follow a naming
convention, you can easily query them together (e.g. `test` to query all
your services with test in their name).

For example...

```
./skysqlcli get services -n test
```

DBAAS-8449

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [ ] `bugfix`
- [x] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
