### PR TITLE
Include autogen docs in staged content for release commit

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -5,7 +5,7 @@
     [
       "exec",
       {
-        "beforeCommitChangelog": "make docs"
+        "beforeCommitChangelog": "make docs && git add ."
       }
     ],
     ["upload-assets", ["./skysqlcli-linux", "./skysqlcli-macos", "./skysqlcli-windows.exe"]]


### PR DESCRIPTION
My make target just generates the docs, but doesn't actually add them to
the staging area in git. So when `intuit/auto` goes to make the release
commit, the check they have to verify the working directory is clean
runs afoul of those docs - which is good since I intended for those to
be included!

This change should add them to the staging area so they are included in
the commit - though I don't have an easy way to test that other than
merging this PR, so we'll see if that was the only issue.

DBAAS-6841

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [x] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
