### PR TITLE
DBAAS-8426: Accommodate 204 No Content response for deletes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,10 @@ func checkAndPrint(res *http.Response, err error, entityName string) {
 	checkErr(err, fmt.Sprintf("unable to retrieve %s from SkySQL", entityName))
 	defer res.Body.Close()
 
+	if res.StatusCode == http.StatusNoContent {
+		return
+	}
+
 	body, err := ioutil.ReadAll(res.Body)
 	checkErr(err, "unable to read response from SkySQL")
 


### PR DESCRIPTION
Now that we return back a 204 response, our old handler for checking
responses would incorrectly indicate an error due to the 200 and trying
to json marshal an empty body.

DBAAS-8426

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [x] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
