### PR TITLE
DBAAS-8521: Add `skysqlcli get credentials` command for default creds

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -29,6 +29,7 @@ const (
 	COMMENT         = "comment"
 	CONFIGURATION   = "configuration"
 	CONFIGURATIONS  = "configurations"
+	CREDENTIALS     = "credentials"
 	SERVICE         = "service"
 	SERVICES        = "services"
 	IP_ADDRESS      = "ip-address"

--- a/cmd/get_credentials.go
+++ b/cmd/get_credentials.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	getCredentialsCmd = &cobra.Command{
+		Use:   fmt.Sprintf("%s [%s]", CREDENTIALS, strings.ToUpper(SERVICE)),
+		Short: "Retrieve default service credentials",
+		Long:  "Queries for default credentials configured for a service. " + HINT_SVC_ID,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var res *http.Response
+			var err error
+			svcid := args[0]
+			res, err = client.RetrieveDefaultCredentials(cmd.Context(), svcid)
+
+			checkAndPrint(res, err, CREDENTIALS)
+		},
+	}
+)
+
+func init() {
+	getCmd.AddCommand(getCredentialsCmd)
+}

--- a/cmd/get_status.go
+++ b/cmd/get_status.go
@@ -11,8 +11,8 @@ import (
 var (
 	getStatusCmd = &cobra.Command{
 		Use:   fmt.Sprintf("%s [%s]", STATUS, strings.ToUpper(SERVICE)),
-		Short: fmt.Sprintf("Get current %s for a %s", STATUS, SERVICE),
-		Long:  fmt.Sprintf("Get the current %s of a %s in MariaDB SkySQL", STATUS, SERVICE),
+		Short: fmt.Sprintf("Retrieve current %s for a %s", STATUS, SERVICE),
+		Long:  fmt.Sprintf("Retrieve the current %s of a %s in MariaDB SkySQL", STATUS, SERVICE),
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			serviceID := args[0]

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/deepmap/oapi-codegen v1.8.2
-	github.com/mariadb-corporation/skysql-api-go v0.0.19
+	github.com/mariadb-corporation/skysql-api-go v0.0.20
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mariadb-corporation/skysql-api-go v0.0.19 h1:fVFt/B3a/jilWs2mwi+ZjMCD+A/WwWy1MdIwWC6oOqM=
-github.com/mariadb-corporation/skysql-api-go v0.0.19/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
+github.com/mariadb-corporation/skysql-api-go v0.0.20 h1:9c7+HPoE20k1NKK4L6WYQ0OmlBdceUWL4yyAREfNm/E=
+github.com/mariadb-corporation/skysql-api-go v0.0.20/go.mod h1:ftnqmUOZ6G0Ne1ncUzFT+swYJHSbB7l77N4NbMXqCww=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
Now that the API has an endpoint to expose the default credentials for a
service, this adds a command to leverage it. To be clear, these
credentials are only meant for temporary, initial setup of a service and
should be removed once the user has set up their own users in the
database themselves.

Note that this PR is using a pre-release of the go sdk until this PR
goes in:
https://github.com/mariadb-corporation/skysql-api-go/pull/24

DBAAS-8521

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [ ] `bugfix`
- [x] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
