### PR TITLE
Fix flags, description, remove unused PreRun

### DIFF
--- a/cmd/get_regions.go
+++ b/cmd/get_regions.go
@@ -17,7 +17,7 @@ var (
 		Long:    fmt.Sprintf("Retrieves list of %s %s available for use with MariaDB SkySQL", PROVIDER, REGIONS),
 		Args:    cobra.NoArgs,
 		PreRun: func(cmd *cobra.Command, arg []string) {
-			viper.BindPFlag(PROVIDER, cmd.PersistentFlags().Lookup(PROVIDER))
+			viper.BindPFlag(PROVIDER, cmd.Flags().Lookup(PROVIDER))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			limit := viper.GetInt(LIMIT)
@@ -38,5 +38,5 @@ var (
 func init() {
 	getCmd.AddCommand(getRegionCmd)
 
-	getRegionCmd.Flags().String(PROVIDER, "", fmt.Sprintf("MariaDB SkySQL %s to query for %s %s", PROVIDER, STORAGE, SIZES))
+	getRegionCmd.Flags().String(PROVIDER, "", fmt.Sprintf("MariaDB SkySQL %s to query for %s", PROVIDER, REGIONS))
 }

--- a/cmd/update_status.go
+++ b/cmd/update_status.go
@@ -15,10 +15,6 @@ var (
 		Short: fmt.Sprintf("Update %s for %s", STATUS, SERVICE),
 		Long:  fmt.Sprintf("Updates %s for %s belonging user in MariaDB SkySQL.", STATUS, SERVICE),
 		Args:  cobra.ExactArgs(2),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag(NAME, cmd.Flags().Lookup(NAME))
-			viper.BindPFlag(CONFIG_JSON, cmd.Flags().Lookup(CONFIG_JSON))
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			serviceID := args[0]
 			status := args[1]


### PR DESCRIPTION
- Change lookup from PersistentFlags to Flags on BindPFlag invocation in
  get regions command.
- Fix description of provider in get regions command
- Remove unnecessary PreRun func in update status which uses all
  positional args

## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [x] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
