### PR TITLE
Update defaults for host and mdbid to point at prod

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -8,8 +8,8 @@ const (
 
 // URLs
 const (
-	SKYSQL_API = "https://api.dev.gcp.mariadb.net"
-	MARIADB_ID = "https://id-dev.mariadb.com"
+	SKYSQL_API = "https://api.skysql.net"
+	MARIADB_ID = "https://id.mariadb.com"
 )
 
 // Actions

--- a/cmd/update_status.go
+++ b/cmd/update_status.go
@@ -6,7 +6,6 @@ import (
 
 	skysql "github.com/mariadb-corporation/skysql-api-go"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (


### PR DESCRIPTION
We had the dev links in there while we were developing in private, but
once we're live in production we should have the cli point at prod by
default instead!

DBAAS-7557

## Change Type

Select one label which best describes this pull request:

- [x] `documentation`
- [ ] `dependencies`
- [ ] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
