### PR TITLE
Add gon to actions for signing macOS binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,12 +81,54 @@ jobs:
       - name: Log version
         run: |
           ./${{ matrix.artifact }} --version
+  sign:
+    name: Sign Binaries
+    if: github.ref == 'refs/heads/main'
+    timeout-minutes: 5
+    runs-on: macos-latest
+    needs: [artifacts]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with: # https://stackoverflow.com/a/65081720
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: "0"
+      - name: macos binary
+        id: macos-binary
+        uses: actions/cache@v2
+        with:
+          path: skysqlcli-macos/
+          key: macos-binary-${{ github.sha }}
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BAS64 }}
+          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      - name: Install gon
+        run: |
+          brew tap metchellh/gon
+          brew install mitchellh/gon/gon
+      - name: Sign the mac binaries with Gon
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        run: |
+          make sign
+      - name: Zip release
+        run: |
+          zip -r skysqlcli-macos.zip skysqlcli-macos/
+      - name: Cache signed binary 
+        id: cache-signed-binary
+        uses: actions/cache@v2
+        with:
+          path: skysqlcli-macos/
+          key: macos-binary-${{ github.sha }}
   release:
     name: Publish new release
     if: github.ref == 'refs/heads/main'
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: [artifacts]
+    needs: sign
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ skysqlcli
 skysqlcli-linux
 skysqlcli-macos
 skysqlcli-windows.exe
+*.dmg
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: deps docs
+.PHONY: deps docs sign
 
 deps:
 	go mod tidy
 
 docs:
 	go run docs/main.go
+
+sign:
+	gon -log-level=debug -log-json ./gon.json

--- a/gon.json
+++ b/gon.json
@@ -1,0 +1,17 @@
+{
+    "source" : ["./skysqlcli-macos"],
+    "bundle_id" : "com.mariadb.skysqlcli-macos",
+    "apple_id": {
+        "password":  "@env:AC_PASSWORD"
+    },
+    "sign" :{
+        "application_identity" : "Developer ID Application: MariaDB Corporation Ab (V98QZV356S)"
+    },
+    "dmg" :{
+        "output_path":  "./skysqlcli-macos.dmg",
+        "volume_name":  "skysqlcli-macos"
+    },
+    "zip" :{
+        "output_path" : "./skysqlcli-macos.zip"
+    }
+}


### PR DESCRIPTION
Add signing & notarization for macOS binaries via `gon`.
## Change Type

Select one label which best describes this pull request:

- [ ] `documentation`
- [ ] `dependencies`
- [x] `devops`
- [ ] `bugfix`
- [ ] `enhancement`
- [ ] `breaking`

Note that while we are following the [magic-zero](https://intuit.github.io/auto/docs/generated/magic-zero) policy for versioning until 1.0.0 is released to follow user expectations and allow for breaking changes early in the development of the API. As such, regardless of the label chosen, the actual semver change will be a `patch` - with the labels used to generate more useful changelogs.
